### PR TITLE
perf: skip banned words check if banned words list is empty

### DIFF
--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -24,6 +24,7 @@ public class BannedWordsFilter extends ListenerAdapter {
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
+        if (LIST_BANNED_WORDS.isEmpty()) return;
 
         var member = event.getMember();
         var modRole = event.getJDA().getRoleById(BotConfig.getModRoleIdLong());


### PR DESCRIPTION
Closes #97

**By opening this pull request I confirm:**
- [x] I tested the code
- [x] I kept things as simple as possible
- [x] I added in-line documentation (if needed)

**Description**

Added a check, if the list LIST_BANNED_WORDS is empty we skip the other code. This is a performance gain for hosts that have empty banned words lists.

General improvement of rembot's performance.

