### PR TITLE
refactor/simplify rembot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
-.env.example
-.idea
-.gradle
 .github
+.gradle
+.idea
 build
-
+.env.example

--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ ANTI_SPAM_STRIKE_AMOUNT=3
 # Words that will be auto-deleted they are split up using "," (COMMA!) (e.g. "badword,badword2,badword3")
 # WHITESPACES are counted as a character keep that in mind to avoid unwanted behaviour.
 BANNED_WORDS=
-# Words that will be EXCLUDED from being auto-deleted they are split up using "," (COMMA!) (e.g. "badword,badword2,badword3")
+# Words that will be EXCLUDED from being auto-deleted they are split up using "," (COMMA!) (e.g. "goodword,goodword2,goodword3")
 # WHITESPACES are counted as a character keep that in mind to avoid unwanted behaviour.
 WHITELISTED_WORDS=
 # Choose an amount banned words will be replicated for (e.g. ["badword", "badwordbadword"]), if unsure keep default.

--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ ROOT_LOG_LEVEL=info
 # as these would be more reliable.
 # For releases check: https://github.com/MikuMikuSenpai/rembot/releases
 IMAGE_TAG=latest
-# rembot can only be connected to ONE server at a time (this is a deliberate decision)
+# rembot can only be connected to ONE (1) server at a time
 GUILD_ID=
 
 # Database password: choose a strong password. With this you are able to query data locally and rembot needs this.
@@ -55,9 +55,9 @@ WHITELISTED_WORDS=
 # (default=10)
 REPLICATE_AMOUNT=10
 # This operation is heavy on the CPU/RAM if you are unsure keep default value (default=2)
-# /!\ Using a big number has the potential to use too much heap memory making the bot freeze.
-# How many substituted words need to be checked, if someone sends a message with a word count higher than you set it will be logged in the log channel.
+# /!\ Using a big number has the potential to freeze rembot.
+# How many substituted words need to be checked.
 SUBSTITUTE_BANNED_WORD_CHECK_AMOUNT=2
-# How many substitute characters are allowed to be in a message for it to still be checked via substitute() (default=3)
-# /!\ Again, using a big number has the potential to freeze rembot use default value if unsure.
+# How many substitute characters are allowed to be in a message for it to still be checked. (default=3)
+# /!\ A big number has the potential to freeze rembot use default value if unsure.
 ALLOWED_AMOUNT_SUBSTITUTE_CHARACTERS_PER_MESSAGE=3

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# guidelines
+* Create a [GitHub issue](https://github.com/MikuMikuSenpai/rembot/issues) relating to what you want to contribute
+* Ask technical question to @acexcy, non-technical to @mikumikusenpai
+* Contribute one problem/functionality at a time (do not combine multiple github issues in one PR)
+
+Project is not dead/abandoned but solo dev project so allow some time before stuff is integrated

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # guidelines
 * Create a [GitHub issue](https://github.com/MikuMikuSenpai/rembot/issues) relating to what you want to contribute
+  * This is required -> double check that a GH issue was created or exists and reference it and is accepted to be worked on so that you don't waste time creating a PR for something that isn't being implemented/needed
 * Ask technical question to @acexcy, non-technical to @mikumikusenpai
 * Contribute one problem/functionality at a time (do not combine multiple github issues in one PR)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,11 +3,9 @@ Closes (LINK TO GH ISSUE)
 **By opening this pull request I confirm:**
 - [ ] I tested the code
 - [ ] I kept things as simple as possible
-- [ ] I added in-line documentation (if needed)
+- [ ] I added in-line documentation (if relevant)
 
 **Description**
-
-A clear and concise description of the PR.
 
 - Summary of changes
 - Reasoning

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Closes (LINK TO GH ISSUE)
 **By opening this pull request I confirm:**
 - [ ] I tested the code
 - [ ] I kept things as simple as possible
-- [ ] I added in-line documentation (if relevant)
+- [ ] I added documentation (if relevant)
 
 **Description**
 

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -33,7 +33,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for specific tag
+      - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 #v6.1.0
         with:
@@ -42,7 +42,7 @@ jobs:
             type=semver,pattern={{version}}
             type=sha
 
-      - name: Build and push Docker image SPECIFIC TAG
+      - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf #v7.2.0
         with:

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -51,11 +51,3 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-#      - name: Build and push Docker image LATEST
-#        id: push
-#        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf #v7.2.0
-#        with:
-#          context: .
-#          push: true
-#          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,12 @@ hs_err_pid*
 replay_pid*
 
 build
+bin
 .gradle
 .idea
 .env
 # Ignore Kotlin plugin data
 .kotlin
+
+# emacs
+\#*\#

--- a/README.md
+++ b/README.md
@@ -33,4 +33,3 @@ For more information regarding docker consult their documentation.
    * Manage Messages
 2. Copy [.env.example](.env.example) and create your own .env variant
 3. ```docker compose -f ./docker-compose-dev.yml up --build```
-   1. Each time you make a change to rembot, you will need to rebuild it using the --build option.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # rembot
 Remastered mbot get it mbot rembot yeah my bad
 
+## Reference Sheet
+
+```text
+[] = optional
+Slash Commands (/)
+    Admin Commands (privileged access)
+        /ban username [reason]
+        /kick username [reason]
+        /mute username minutes [hours] [reason]
+        /unban username [reason]
+        /unmute username [reason]
+Non-Slash Commands (&)
+    &ping - returns "pong", time took in milliseconds (ms) and what version of rembot is running.
+```
+
 ## Quickstart:
 
 ### Production/Hosting:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,24 +16,25 @@ application {
 
 dependencies {
     implementation("net.dv8tion:JDA:6.4.1") {
-        exclude(module = "opus-java") // for audio stuff dont need this
-        exclude(module = "tink") // for encrypting and decrypting audio, dont need this
+        //audio stuff
+        exclude(module = "opus-java")
+        exclude(module = "tink")
     }
 
-    implementation("com.mysql:mysql-connector-j:9.7.0")//mysql database jdbc
-    implementation("com.zaxxer:HikariCP:7.0.2")//for connection pooling = performance
+    implementation("com.mysql:mysql-connector-j:9.7.0")
+    implementation("com.zaxxer:HikariCP:7.0.2") // Connection pooling = performance
 
-    implementation("ch.qos.logback:logback-classic:1.5.34") // needed for logging (https://jda.wiki/setup/logging/)
+    implementation("ch.qos.logback:logback-classic:1.5.34") // (https://jda.wiki/setup/logging/)
 
-    compileOnly("org.projectlombok:lombok:1.18.46") // lombok = less boilerplate code
-    annotationProcessor("org.projectlombok:lombok:1.18.46") // lombok = less boilerplate code
-    testCompileOnly("org.projectlombok:lombok:1.18.46") // lombok = less boilerplate code
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.46") // lombok = less boilerplate code
+    compileOnly("org.projectlombok:lombok:1.18.46")
+    annotationProcessor("org.projectlombok:lombok:1.18.46")
+    testCompileOnly("org.projectlombok:lombok:1.18.46")
+    testAnnotationProcessor("org.projectlombok:lombok:1.18.46")
 
-    testImplementation(libs.junit.jupiter) //testing bs
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher") //testing bs
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    implementation(libs.guava) // no clue why we need this but gradle included it
+    implementation(libs.guava)
 }
 
 java {

--- a/database.sql
+++ b/database.sql
@@ -1,5 +1,6 @@
 -- THIS IS THE INIT SCRIPT FOR BUILDING OUR MYSQL DATABASE LAYOUT
 -- IF WORKING ON THIS MAKE SURE TO DELETE VOLUMES ETC CUS OLD LAYOUT COULD STILL BE HERE FORCE DOCKER TO REBUILD IT
+-- keeping the reminder ^^ its (a bit) noob but im gonna forget
 SET GLOBAL event_scheduler = ON;
 
 CREATE TABLE users(
@@ -13,7 +14,7 @@ CREATE TABLE messages(
     user_id BIGINT NOT NULL,
     time_created TIMESTAMP NOT NULL,
     message_content VARCHAR(4000) NOT NULL,
-    -- 5000 chars should be plenti i think? these max would be 10 links in total including whitespaces between them
+    -- 5000 chars should be enough? these would be maximum 10 links in total including whitespaces between them
     attachments_links VARCHAR(5000) NOT NULL,
 
     PRIMARY KEY(discord_message_id),
@@ -38,15 +39,12 @@ CREATE TABLE strikes_spam(
     PRIMARY KEY(discord_user_id)
 );
 
--- check every 12 hours if there are messages younger than 1 week delete those to clean DB.
--- We are checking these frequently cus could build up fast compared to other data.
 CREATE EVENT clean_messages
     ON SCHEDULE
     EVERY 12 HOUR
     DO
     DELETE FROM messages WHERE DATE_ADD(time_created, INTERVAL 1 WEEK) < NOW();
 
--- clean starred messages that have discord_message_id that is NOT in messages table (message is not stored in DB)
 CREATE EVENT clean_starred_messages
     ON SCHEDULE
     EVERY 12 HOUR
@@ -56,7 +54,6 @@ CREATE EVENT clean_starred_messages
         FROM messages
     );
 
--- checks every day if a strike is a week old = delete
 CREATE EVENT clean_strikes_spam
     ON SCHEDULE
     EVERY 1 DAY

--- a/src/main/java/va/rembot/Bot.java
+++ b/src/main/java/va/rembot/Bot.java
@@ -22,20 +22,15 @@ public class Bot {
                     BOT_TOKEN,
                     GatewayIntent.GUILD_MESSAGES,
                     GatewayIntent.MESSAGE_CONTENT,
-                    GatewayIntent.GUILD_MESSAGE_REACTIONS,//need this for star bs thing
-                    GatewayIntent.GUILD_MEMBERS)//DO NOT delete this intent, this will make sure cache is updated if
-                    // members leave cus currently its on ALL (MemberCachePolicy.ALL)
-                    // and users would stay infinitely in cache but this intent prevents that
-                    // (removes them if they leave guild)
+                    GatewayIntent.GUILD_MESSAGE_REACTIONS,
+                    GatewayIntent.GUILD_MEMBERS)
                     .disableCache( // this is to ignore the jda warnings, might need to enable these in the future
                             CacheFlag.VOICE_STATE,
                             CacheFlag.EMOJI,
                             CacheFlag.STICKER,
                             CacheFlag.SCHEDULED_EVENTS,
                             CacheFlag.SOUNDBOARD_SOUNDS)
-                    .setMemberCachePolicy(MemberCachePolicy.ALL)//this could be bad in the future if dead server
-                    // would become huge but for now this is fine and the easiest need
-                    // to cache members for example for unmuting
+                    .setMemberCachePolicy(MemberCachePolicy.ALL)//if server becomes big change this
                     .build();
             printLogo();
         } catch (InvalidTokenException e) {
@@ -45,8 +40,7 @@ public class Bot {
             log.error(e.getMessage());
         }
 
-        bot
-                .getApplicationManager()
+        bot.getApplicationManager()
                 .setDescription("Bot made so i can mess around\n\nhttps://github.com/MikuMikuSenpai/rembot")
                 .queue();
 
@@ -55,11 +49,11 @@ public class Bot {
 
     private static void printLogo(){
         // credits: https://www.asciiart.eu/text-to-ascii-art
-        // Update below configuration so that the logo can be updated correctly on new version releases
-        // Current input text "REMBOT v0.0.0 PRERELEASE"
+        // Keep below updated on every release
+        // input_text: "REMBOT v0.0.0 PRERELEASE"
         // Font: standard Normal Normal 80
-        // None
-        // None
+        // None 0 0
+        // None standard 14pt
         // Whitespace Break | Trim Whitespace
         log.info(" ____  _____ __  __ ____   ___ _____          ___   ___   ___  ");
         log.info("|  _ \\| ____|  \\/  | __ ) / _ \\_   _| __   __/ _ \\ / _ \\ / _ \\ ");

--- a/src/main/java/va/rembot/BotConfig.java
+++ b/src/main/java/va/rembot/BotConfig.java
@@ -2,6 +2,7 @@ package va.rembot;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.session.ReadyEvent;
@@ -20,9 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/// All global variables should be here
-/// Configuration related to EventListeners and adding slash commands should be set in "onReady" method
-/// The "onReady" method ensures rembot is fully loaded/started
+/// All global variables should be here and configuration is done here
 @Slf4j
 public class BotConfig extends ListenerAdapter {
 
@@ -64,7 +63,7 @@ public class BotConfig extends ListenerAdapter {
     @Override
     public void onReady(ReadyEvent event) {
 
-        var bot = event.getJDA();
+        JDA bot = event.getJDA();
 
         try {
             modRoleIdLong = Long.parseLong(MOD_ROLE_ID);
@@ -262,8 +261,6 @@ public class BotConfig extends ListenerAdapter {
                                 .addOption(OptionType.USER, "username", "The user to be unmuted.", true)
                                 .addOption(OptionType.STRING, "reason", "Reason for unmute.", false))
                 .queue(success -> log.info("Successfully loaded all slash commands."));
-
-
     }
 
     private static String[] getBannedWordsArray() {

--- a/src/main/java/va/rembot/BotConfig.java
+++ b/src/main/java/va/rembot/BotConfig.java
@@ -268,7 +268,7 @@ public class BotConfig extends ListenerAdapter {
 
     private static String[] getBannedWordsArray() {
 
-        var replicateAmountInt = EnvHelper.getREPLICATE_AMOUNT_INT();
+        int replicateAmountInt = EnvHelper.getREPLICATE_AMOUNT_INT();
 
         List<String> bannedWordsListTemp = new ArrayList<>();
         List<String> bannedWordsList = new ArrayList<>(Arrays.asList(BANNED_WORDS_ARRAY_TEMP));
@@ -276,33 +276,33 @@ public class BotConfig extends ListenerAdapter {
         log.debug("[getBannedWordsArray] Current new bannedWordsList: {}", bannedWordsList);
         log.debug("[getBannedWordsArray] replicateAmountInt {}", replicateAmountInt);
 
-        for (var word : bannedWordsList) {
-            var newBannedWord = "";
+        for (String word : bannedWordsList) {
+            StringBuilder newBannedWord = new StringBuilder();
 
             //amount of time to replicate word which means: word wordword wordwordword wordwordwordword
             for (int i = 1; i <= replicateAmountInt; i++) {
 
-                newBannedWord = word.repeat(i);
-                bannedWordsListTemp.add(newBannedWord);
+                newBannedWord.setLength(0);
+                newBannedWord.append(word.repeat(i));
+                bannedWordsListTemp.add(newBannedWord.toString());
 
                 log.debug("[getBannedWordsArray] Building word: {}", newBannedWord);
                 log.debug("[getBannedWordsArray] Building list: {}", bannedWordsListTemp);
-
             }
         }
 
-        for (var word : bannedWordsList) {
-            var newBannedWord = "";
+        for (String word : bannedWordsList) {
+            StringBuilder newBannedWord = new StringBuilder();
 
             //plural form +s
             for (int i = 1; i <= replicateAmountInt; i++) {
 
-                newBannedWord = word.repeat(i) + "s";
-                bannedWordsListTemp.add(newBannedWord);
+                newBannedWord.setLength(0);
+                newBannedWord.append(word.repeat(i) + "s");
+                bannedWordsListTemp.add(newBannedWord.toString());
 
                 log.debug("[getBannedWordsArray] Building word plural: {}", newBannedWord);
                 log.debug("[getBannedWordsArray] Building list plural: {}", bannedWordsListTemp);
-
             }
         }
 

--- a/src/main/java/va/rembot/BotConfig.java
+++ b/src/main/java/va/rembot/BotConfig.java
@@ -62,8 +62,6 @@ public class BotConfig extends ListenerAdapter {
     private static int allowedAmountSubstituteCharactersPerMessage = 0;
 
     @Override
-    //we assign the ENV vars first to be sure that they are the correct values
-    // before using them in all the other files
     public void onReady(ReadyEvent event) {
 
         var bot = event.getJDA();
@@ -76,7 +74,6 @@ public class BotConfig extends ListenerAdapter {
             log.error("[onReady] MOD_ROLE_ID ENV VAR MISSING The bot cannot start until this is fixed.");
             log.error("[onReady] MOD_ROLE_ID ENV VAR MISSING error: {}", e.getMessage());
             bot.shutdown();
-
         }
 
         try {
@@ -93,7 +90,6 @@ public class BotConfig extends ListenerAdapter {
             log.error("[onReady] ANTI_SPAM_TIME_AMOUNT ENV VAR MISSING The bot cannot start until this is fixed.");
             log.error("[onReady] ANTI_SPAM_TIME_AMOUNT ENV VAR MISSING error: {}", e.getMessage());
             bot.shutdown();
-
         }
 
         try {
@@ -110,37 +106,32 @@ public class BotConfig extends ListenerAdapter {
             log.error("[onReady] ANTI_SPAM_MUTE_AMOUNT ENV VAR MISSING The bot cannot start until this is fixed.");
             log.error("[onReady] ANTI_SPAM_MUTE_AMOUNT ENV VAR MISSING error: {}", e.getMessage());
             bot.shutdown();
-
         }
 
         try {
             antiSpamStrikeAmountInt = Integer.parseInt(ANTI_SPAM_STRIKE_AMOUNT);
 
-            if (antiSpamStrikeAmountInt <= 0) {
+            if (antiSpamStrikeAmountInt <= 0)
                 log.warn("[onReady] ANTI_SPAM_STRIKE_AMOUNT is 0 or a negative number, this means that people will be instantly banned if spamming this is probably NOT what you want. Check your .env file.");
-            }
         } catch (NumberFormatException e) {
 
             log.error("[onReady] ANTI_SPAM_STRIKE_AMOUNT ENV VAR MISSING Check your .env file it is missing values use .env.example as a guide.");
             log.error("[onReady] ANTI_SPAM_STRIKE_AMOUNT ENV VAR MISSING The bot cannot start until this is fixed.");
             log.error("[onReady] ANTI_SPAM_STRIKE_AMOUNT ENV VAR MISSING error: {}", e.getMessage());
             bot.shutdown();
-
         }
 
         try {
             substituteBannedWordCheckAmountInt = Integer.parseInt(SUBSTITUTE_BANNED_WORD_CHECK_AMOUNT);
 
-            if (substituteBannedWordCheckAmountInt <= 0) {
+            if (substituteBannedWordCheckAmountInt <= 0)
                 log.warn("[onReady] SUBSTITUTE_BANNED_WORD_CHECK_AMOUNT is 0 or a negative number, this breaks banned word check. Change it to a positive number. Check your .env file.");
-            }
         } catch (NumberFormatException e) {
 
             log.error("[onReady] SUBSTITUTE_BANNED_WORD_CHECK_AMOUNT ENV VAR MISSING Check your .env file it is missing values use .env.example as a guide.");
             log.error("[onReady] SUBSTITUTE_BANNED_WORD_CHECK_AMOUNT ENV VAR MISSING The bot cannot start until this is fixed.");
             log.error("[onReady] SUBSTITUTE_BANNED_WORD_CHECK_AMOUNT ENV VAR MISSING error: {}", e.getMessage());
             bot.shutdown();
-
         }
 
         try {
@@ -156,16 +147,14 @@ public class BotConfig extends ListenerAdapter {
         try {
             allowedAmountSubstituteCharactersPerMessage = Integer.parseInt(ALLOWED_AMOUNT_SUBSTITUTE_CHARACTERS_PER_MESSAGE);
 
-            if (allowedAmountSubstituteCharactersPerMessage <= 0) {
+            if (allowedAmountSubstituteCharactersPerMessage <= 0)
                 log.warn("[onReady] ALLOWED_AMOUNT_SUBSTITUTE_CHARACTERS_PER_MESSAGE is 0 or a negative number, this breaks banned word check. Change it to a positive number. Check your .env file.");
-            }
         } catch (NumberFormatException e) {
 
             log.error("[onReady] ALLOWED_AMOUNT_SUBSTITUTE_CHARACTERS_PER_MESSAGE ENV VAR MISSING Check your .env file it is missing values use .env.example as a guide.");
             log.error("[onReady] ALLOWED_AMOUNT_SUBSTITUTE_CHARACTERS_PER_MESSAGE ENV VAR MISSING The bot cannot start until this is fixed.");
             log.error("[onReady] ALLOWED_AMOUNT_SUBSTITUTE_CHARACTERS_PER_MESSAGE ENV VAR MISSING error: {}", e.getMessage());
             bot.shutdown();
-
         }
 
         if (bot.getGuilds().size() > 1) {
@@ -193,7 +182,7 @@ public class BotConfig extends ListenerAdapter {
             log.error("[onReady] MOD_ROLE_ID {} is not valid, fix your .env file.", MOD_ROLE_ID);
             log.error("[onReady] rembot can not start without fixing this issue first.");
             bot.shutdown();
-        } catch (IllegalArgumentException e) {} // catching error if its empty this is handled by the ENV var check above
+        } catch (IllegalArgumentException e) {}
 
         try {
             bot.getChannelById(TextChannel.class, LOG_CHANNEL_ID).getJDA();
@@ -232,9 +221,8 @@ public class BotConfig extends ListenerAdapter {
             bot.shutdown();
         }
 
-        if (EnvHelper.getREPLICATE_AMOUNT_INT() <= 0) {
+        if (EnvHelper.getREPLICATE_AMOUNT_INT() <= 0)
             log.warn("[onReady] REPLICATE_AMOUNT is set to 0 or a negative number, this means that banned words are not replicated this is probably not what you want. Check your .env file.");
-        }
 
         bot.addEventListener(
                 new Ban(),
@@ -278,15 +266,11 @@ public class BotConfig extends ListenerAdapter {
 
     }
 
-    /// returns a string with replicas of the banned words including plural form this eases the bot hosting for the hoster
-    /// normally they would have to manually type "badword,badwordbadword" etc. for the edge cases where users
-    /// send bad words next to each other to avoid censor but this is automated now, including plural form (+s)
-    /// other plural forms (e.g. +es) need to be added by the host in their .env (this can be added later but not urgent)
     private static String[] getBannedWordsArray() {
 
         var replicateAmountInt = EnvHelper.getREPLICATE_AMOUNT_INT();
 
-        List<String> bannedWordsListTemp = new ArrayList<>(); //used for adding replicated words during iterations afterward all the items are added to real list
+        List<String> bannedWordsListTemp = new ArrayList<>();
         List<String> bannedWordsList = new ArrayList<>(Arrays.asList(BANNED_WORDS_ARRAY_TEMP));
 
         log.debug("[getBannedWordsArray] Current new bannedWordsList: {}", bannedWordsList);

--- a/src/main/java/va/rembot/EnvHelper.java
+++ b/src/main/java/va/rembot/EnvHelper.java
@@ -22,8 +22,7 @@ public class EnvHelper {
             log.error("[getInt] REPLICATE_AMOUNT ENV VAR MISSING Check your .env file it is missing values use .env.example as a guide.");
             log.error("[getInt] REPLICATE_AMOUNT ENV VAR MISSING The bot cannot start until this is fixed.");
             log.error("[getInt] REPLICATE_AMOUNT ENV VAR MISSING error: {}", e.getMessage());
-            System.exit(1); // force stop rembot
-
+            System.exit(1);
             return 0;
         }
     }

--- a/src/main/java/va/rembot/EnvHelper.java
+++ b/src/main/java/va/rembot/EnvHelper.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-/// Helper method for loading ENV variables that are to be used within BotConfig
+/// Helper for loading ENV variables to use within BotConfig
 public class EnvHelper {
 
     private static final String REPLICATE_AMOUNT = System.getenv("REPLICATE_AMOUNT");

--- a/src/main/java/va/rembot/commands/non_slash/PingPong.java
+++ b/src/main/java/va/rembot/commands/non_slash/PingPong.java
@@ -1,5 +1,6 @@
 package va.rembot.commands.non_slash;
 
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import va.rembot.BotConfig;
@@ -16,7 +17,7 @@ public class PingPong extends ListenerAdapter {
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
 
-        var msg = event.getMessage();//TODO: fix name conflict with JDA's "message"
+        Message msg = event.getMessage();
         String msgRaw = msg.getContentRaw();
 
         if (msgRaw.equals("&ping")) {

--- a/src/main/java/va/rembot/commands/non_slash/PingPong.java
+++ b/src/main/java/va/rembot/commands/non_slash/PingPong.java
@@ -16,15 +16,15 @@ public class PingPong extends ListenerAdapter {
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
 
-        var msg = event.getMessage();
-        var msgRaw = msg.getContentRaw();
+        var msg = event.getMessage();//TODO: fix name conflict with JDA's "message"
+        String msgRaw = msg.getContentRaw();
 
-        if (msgRaw.equals("&ping")){
-            var timeSent = msg.getTimeCreated().toLocalDateTime();
-            var timeNow = LocalDateTime.now();
-            var timeTook = Duration.between(timeSent, timeNow).abs().getNano();
-            var timeTookInMs = (double) timeTook / 1_000_000;
-            var df = new DecimalFormat("#.##"); // only print 2 decimals
+        if (msgRaw.equals("&ping")) {
+            LocalDateTime timeSent = msg.getTimeCreated().toLocalDateTime();
+            LocalDateTime timeNow = LocalDateTime.now();
+            int timeTook = Duration.between(timeSent, timeNow).abs().getNano();
+            double timeTookInMs = (double) timeTook / 1_000_000;
+            DecimalFormat df = new DecimalFormat("#.##");
 
             msg
                     .reply("pong (took " + df.format(timeTookInMs) + " ms) [version: " + BotConfig.IMAGE_TAG + "]")

--- a/src/main/java/va/rembot/commands/slash/admin/Ban.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Ban.java
@@ -18,7 +18,7 @@ public class Ban extends ListenerAdapter {
 
             User target = event.getOption("username").getAsUser();
             UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
-            User slashCommandUser = event.getInteraction().getUser();
+            User slashCommandUser = event.getUser();
             String reason;
 
             try {

--- a/src/main/java/va/rembot/commands/slash/admin/Ban.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Ban.java
@@ -1,6 +1,7 @@
 package va.rembot.commands.slash.admin;
 
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -15,18 +16,18 @@ public class Ban extends ListenerAdapter {
 
             event.deferReply(true).queue();
 
-            var target = event.getOption("username").getAsUser();
-            var usrSnowflake = UserSnowflake.fromId(target.getId());
-            var slashCommandUser = event.getInteraction().getUser();
+            User target = event.getOption("username").getAsUser();
+            UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
+            User slashCommandUser = event.getInteraction().getUser();
+            String reason;
 
-            // "reason" is an optional input, could be null so handle it:
             try {
-                var reason = event.getOption("reason").getAsString();
-                ModerationLib.banUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
+                reason = event.getOption("reason").getAsString();
             } catch (NullPointerException e) {
-                var reason = "No reason provided.";
-                ModerationLib.banUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
+                reason = "No reason provided.";
             }
+
+            ModerationLib.banUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
         }
     }
 }

--- a/src/main/java/va/rembot/commands/slash/admin/Ban.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Ban.java
@@ -12,7 +12,7 @@ public class Ban extends ListenerAdapter {
 
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
-        if (event.getName().equals("ban")){
+        if (event.getName().equals("ban")) {
 
             event.deferReply(true).queue();
 

--- a/src/main/java/va/rembot/commands/slash/admin/Kick.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Kick.java
@@ -12,7 +12,7 @@ public class Kick extends ListenerAdapter {
 
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
-        if (event.getName().equals("kick")){
+        if (event.getName().equals("kick")) {
 
             event.deferReply(true).queue();
 

--- a/src/main/java/va/rembot/commands/slash/admin/Kick.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Kick.java
@@ -1,6 +1,7 @@
 package va.rembot.commands.slash.admin;
 
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -13,19 +14,20 @@ public class Kick extends ListenerAdapter {
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
         if (event.getName().equals("kick")){
 
-           event.deferReply(true).queue();
+            event.deferReply(true).queue();
 
-           var target = event.getOption("username").getAsUser();
-           var usrSnowflake = UserSnowflake.fromId(target.getId());
-           var slashCommandUser = event.getInteraction().getUser();
+            User target = event.getOption("username").getAsUser();
+            UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
+            User slashCommandUser = event.getInteraction().getUser();
+            String reason;
 
-           // "reason" is an optional input, could be null so handle it:
-           try {
-               var reason = event.getOption("reason").getAsString();
-               ModerationLib.kickUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
-           } catch (NullPointerException e) {
-               ModerationLib.kickUsingSlashCommand(event, usrSnowflake, "No reason provided.", slashCommandUser, target);
-           }
+            try {
+                reason = event.getOption("reason").getAsString();
+            } catch (NullPointerException e) {
+                reason = "No reason provided.";
+            }
+
+            ModerationLib.kickUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
         }
     }
 }

--- a/src/main/java/va/rembot/commands/slash/admin/Kick.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Kick.java
@@ -18,7 +18,7 @@ public class Kick extends ListenerAdapter {
 
             User target = event.getOption("username").getAsUser();
             UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
-            User slashCommandUser = event.getInteraction().getUser();
+            User slashCommandUser = event.getUser();
             String reason;
 
             try {

--- a/src/main/java/va/rembot/commands/slash/admin/Mute.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Mute.java
@@ -1,6 +1,7 @@
 package va.rembot.commands.slash.admin;
 
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -15,22 +16,22 @@ public class Mute extends ListenerAdapter {
 
             event.deferReply(true).queue();
 
-            var reason = "No reason provided";
-            var target = event.getOption("username").getAsUser();
-            var minutes = event.getOption("minutes").getAsInt();
-            var usrSnowflake = UserSnowflake.fromId(target.getId());
-            var slashCommandUser = event.getInteraction().getUser();
+            User target = event.getOption("username").getAsUser();
+            int minutes = event.getOption("minutes").getAsInt();
+            UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
+            User slashCommandUser = event.getInteraction().getUser();
+            String reason;
 
-            // "reason" is an optional input, could be null so handle it:
             try {
                 reason = event.getOption("reason").getAsString();
-            } catch (NullPointerException ignored) {}
+            } catch (NullPointerException ignored) {
+                reason = "No reason provided.";
+            }
 
-            // "hours" is an optional input, could be null so handle it:
             try {
-                var hours = event.getOption("hours").getAsInt();
-                var hoursToMinutes = hours * 60;
-                var totalMuteTime = minutes + hoursToMinutes;
+                int hours = event.getOption("hours").getAsInt();
+                int hoursToMinutes = hours * 60;
+                int totalMuteTime = minutes + hoursToMinutes;
                 ModerationLib.muteUsingSlashCommand(event, usrSnowflake, reason, totalMuteTime, slashCommandUser, target);
             } catch (NullPointerException e) {
                 ModerationLib.muteUsingSlashCommand(event, usrSnowflake, reason, minutes, slashCommandUser, target);

--- a/src/main/java/va/rembot/commands/slash/admin/Mute.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Mute.java
@@ -19,7 +19,7 @@ public class Mute extends ListenerAdapter {
             User target = event.getOption("username").getAsUser();
             int minutes = event.getOption("minutes").getAsInt();
             UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
-            User slashCommandUser = event.getInteraction().getUser();
+            User slashCommandUser = event.getUser();
             String reason;
 
             try {

--- a/src/main/java/va/rembot/commands/slash/admin/Unban.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Unban.java
@@ -12,7 +12,7 @@ public class Unban extends ListenerAdapter {
 
     @Override
     public void onSlashCommandInteraction(SlashCommandInteractionEvent event) {
-        if (event.getName().equals("unban")){
+        if (event.getName().equals("unban")) {
 
             event.deferReply(true).queue();
 

--- a/src/main/java/va/rembot/commands/slash/admin/Unban.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Unban.java
@@ -1,6 +1,7 @@
 package va.rembot.commands.slash.admin;
 
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -15,17 +16,18 @@ public class Unban extends ListenerAdapter {
 
             event.deferReply(true).queue();
 
-            var target = event.getOption("username").getAsUser();
-            var usrSnowflake = UserSnowflake.fromId(target.getId());
-            var slashCommandUser = event.getInteraction().getUser();
+            User target = event.getOption("username").getAsUser();
+            UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
+            User slashCommandUser = event.getInteraction().getUser();
+            String reason;
 
-            // "reason" is an optional input, could be null so handle it:
             try {
-                var reason = event.getOption("reason").getAsString();
-                ModerationLib.unbanUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
+                reason = event.getOption("reason").getAsString();
             } catch (NullPointerException e) {
-                ModerationLib.unbanUsingSlashCommand(event, usrSnowflake, "No reason provided.", slashCommandUser, target);
+                reason = "No reason provided.";
             }
+
+            ModerationLib.unbanUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
         }
     }
 }

--- a/src/main/java/va/rembot/commands/slash/admin/Unban.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Unban.java
@@ -18,7 +18,7 @@ public class Unban extends ListenerAdapter {
 
             User target = event.getOption("username").getAsUser();
             UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
-            User slashCommandUser = event.getInteraction().getUser();
+            User slashCommandUser = event.getUser();
             String reason;
 
             try {

--- a/src/main/java/va/rembot/commands/slash/admin/Unmute.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Unmute.java
@@ -1,5 +1,6 @@
 package va.rembot.commands.slash.admin;
 
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -13,20 +14,22 @@ public class Unmute extends ListenerAdapter {
 
             event.deferReply(true).queue();
 
-            var target = event.getOption("username").getAsUser();
+            User target = event.getOption("username").getAsUser();
 
-            if (!event.getGuild().getMemberById(target.getId()).isTimedOut()) { //if user != timedout dont unmute
+            if (!event.getGuild().getMemberById(target.getId()).isTimedOut()) {
                 event.getHook().editOriginal("This user is not muted, can't unmute them.").queue();
                 return;
             }
 
-            var reason = "No reason provided";
-            var usrSnowflake = UserSnowflake.fromId(target.getId());
-            var slashCommandUser = event.getUser();
+            String reason;
+            UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
+            User slashCommandUser = event.getUser();
 
             try {
                 reason = event.getOption("reason").getAsString();
-            } catch (NullPointerException ignored) {}
+            } catch (NullPointerException e) {
+                reason = "No reason provided.";
+            }
 
             ModerationLib.unmuteUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
 

--- a/src/main/java/va/rembot/commands/slash/admin/Unmute.java
+++ b/src/main/java/va/rembot/commands/slash/admin/Unmute.java
@@ -22,7 +22,6 @@ public class Unmute extends ListenerAdapter {
             }
 
             String reason;
-            UserSnowflake usrSnowflake = UserSnowflake.fromId(target.getId());
             User slashCommandUser = event.getUser();
 
             try {
@@ -31,7 +30,7 @@ public class Unmute extends ListenerAdapter {
                 reason = "No reason provided.";
             }
 
-            ModerationLib.unmuteUsingSlashCommand(event, usrSnowflake, reason, slashCommandUser, target);
+            ModerationLib.unmuteUsingSlashCommand(event, reason, slashCommandUser, target);
 
         }
     }

--- a/src/main/java/va/rembot/database/dao/Dao.java
+++ b/src/main/java/va/rembot/database/dao/Dao.java
@@ -3,7 +3,6 @@ package va.rembot.database.dao;
 import java.util.List;
 import java.util.Optional;
 
-//these are the basic CRUD, more can be added in specific DAOs
 public interface Dao<T> {
 
     void create(T t);

--- a/src/main/java/va/rembot/database/dao/MessageDao.java
+++ b/src/main/java/va/rembot/database/dao/MessageDao.java
@@ -23,6 +23,16 @@ public class MessageDao implements Dao<Message>{
         try (Connection conn = DataSource.getConnection();
              PreparedStatement pStmt = conn.prepareStatement(query)){
 
+            if (message.messageContent().length() > 4000){
+                log.error("Message content is too long. Message could not be stored in the database.");
+                throw new SQLException();
+            }
+
+            if (message.attachmentsLinks().length() > 5000){
+                log.error("Attachment links are too long. Message could not be stored in the database.");
+                throw new SQLException();
+            }
+
             pStmt.setLong(1, message.discordMessageId());
             pStmt.setLong(2, message.discordId());
             pStmt.setTimestamp(3, message.timeCreated());

--- a/src/main/java/va/rembot/database/dao/MessageDao.java
+++ b/src/main/java/va/rembot/database/dao/MessageDao.java
@@ -5,10 +5,7 @@ import va.rembot.BotConfig;
 import va.rembot.database.DataSource;
 import va.rembot.database.models.Message;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.List;
 import java.util.Optional;
 
@@ -61,19 +58,20 @@ public class MessageDao implements Dao<Message>{
 
             ps.setLong(1, discordMsgId);
 
-            var result = ps.executeQuery();
-            var discordUserId = 0L;
+            ResultSet result = ps.executeQuery();
+            long discordUserId = 0L;
             Timestamp timeCreated = null;
-            var messageContent = "";
-            var attachmentLinks = "";
+            String messageContent = "";
+            String attachmentLinks = "";
 
             while (result.next()) {
                 discordUserId = result.getLong(2);
                 timeCreated = result.getTimestamp(3);
                 messageContent = result.getString(4);
                 attachmentLinks = result.getString(5);
-                msg = new Message(discordMsgId, discordUserId, timeCreated, messageContent, attachmentLinks);
             }
+
+            msg = new Message(discordMsgId, discordUserId, timeCreated, messageContent, attachmentLinks);
 
         } catch (SQLException e) {
             log.error("Could not get message.");
@@ -104,11 +102,11 @@ public class MessageDao implements Dao<Message>{
 
             ps.setLong(1, discordId);
 
-            var result = ps.executeQuery();
-            var discordMsgId = 0L;
+            ResultSet result = ps.executeQuery();
+            long discordMsgId = 0L;
             Timestamp timeCreated = null;
-            var messageContent = "";
-            var attachmentLinks = "";
+            String messageContent = "";
+            String attachmentLinks = "";
 
             while (result.next()) {
                 discordMsgId = result.getLong(1);
@@ -143,8 +141,8 @@ public class MessageDao implements Dao<Message>{
 
             ps.setLong(1, discordId);
 
-            var result = ps.executeQuery();
-            var discordMsgId = 0L;
+            ResultSet result = ps.executeQuery();
+            long discordMsgId = 0L;
             Timestamp timeCreated = null;
             String messageContent = "";
             String attachmentLinks = "";

--- a/src/main/java/va/rembot/database/dao/MessageDao.java
+++ b/src/main/java/va/rembot/database/dao/MessageDao.java
@@ -3,29 +3,29 @@ package va.rembot.database.dao;
 import lombok.extern.slf4j.Slf4j;
 import va.rembot.BotConfig;
 import va.rembot.database.DataSource;
-import va.rembot.database.models.Message;
+import va.rembot.database.models.DiscordMessage;
 
 import java.sql.*;
 import java.util.List;
 import java.util.Optional;
 
 @Slf4j
-public class MessageDao implements Dao<Message>{
+public class MessageDao implements Dao<DiscordMessage> {
 
     @Override
-    public void create(Message message) {
+    public void create(DiscordMessage message) {
 
         String query = "INSERT IGNORE INTO messages (discord_message_id, user_id, time_created, message_content, attachments_links) VALUES (?, ?, ?, ?, ?)";
 
         try (Connection conn = DataSource.getConnection();
-             PreparedStatement pStmt = conn.prepareStatement(query)){
+             PreparedStatement pStmt = conn.prepareStatement(query)) {
 
-            if (message.messageContent().length() > 4000){
+            if (message.messageContent().length() > 4000) {
                 log.error("Message content is too long. Message could not be stored in the database.");
                 throw new SQLException();
             }
 
-            if (message.attachmentsLinks().length() > 5000){
+            if (message.attachmentsLinks().length() > 5000) {
                 log.error("Attachment links are too long. Message could not be stored in the database.");
                 throw new SQLException();
             }
@@ -47,14 +47,14 @@ public class MessageDao implements Dao<Message>{
     }
 
     @Override
-    public Optional<Message> get(long discordMsgId) {
+    public Optional<DiscordMessage> get(long discordMsgId) {
 
-        Message msg = null;
+        DiscordMessage msg = null;
 
         String query = "SELECT * FROM messages WHERE discord_message_id = ?";
 
         try (Connection conn = DataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(query)){
+             PreparedStatement ps = conn.prepareStatement(query)) {
 
             ps.setLong(1, discordMsgId);
 
@@ -71,7 +71,7 @@ public class MessageDao implements Dao<Message>{
                 attachmentLinks = result.getString(5);
             }
 
-            msg = new Message(discordMsgId, discordUserId, timeCreated, messageContent, attachmentLinks);
+            msg = new DiscordMessage(discordMsgId, discordUserId, timeCreated, messageContent, attachmentLinks);
 
         } catch (SQLException e) {
             log.error("Could not get message.");
@@ -84,13 +84,13 @@ public class MessageDao implements Dao<Message>{
     }
 
     @Override
-    public List<Message> getAll() {
+    public List<DiscordMessage> getAll() {
         return List.of();
     }
 
-    public Optional<Message> getFirst(long discordId) {
+    public Optional<DiscordMessage> getFirst(long discordId) {
 
-        Message msgSpam = null;
+        DiscordMessage msgSpam = null;
 
         String query =
                 "SELECT * FROM " +
@@ -98,7 +98,7 @@ public class MessageDao implements Dao<Message>{
                 "ORDER BY time_created ASC LIMIT 1";
 
         try (Connection conn = DataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(query)){
+             PreparedStatement ps = conn.prepareStatement(query)) {
 
             ps.setLong(1, discordId);
 
@@ -116,7 +116,7 @@ public class MessageDao implements Dao<Message>{
                 attachmentLinks = result.getString(5);
             }
 
-            msgSpam = new Message(discordMsgId, discordId, timeCreated, messageContent, attachmentLinks);
+            msgSpam = new DiscordMessage(discordMsgId, discordId, timeCreated, messageContent, attachmentLinks);
 
         } catch (SQLException e) {
             log.error("Could not get first message for spam detection.");
@@ -127,9 +127,9 @@ public class MessageDao implements Dao<Message>{
         return Optional.of(msgSpam);
     }
 
-    public Optional<Message> getLatest(long discordId) {
+    public Optional<DiscordMessage> getLatest(long discordId) {
 
-        Message msgSpam = null;
+        DiscordMessage msgSpam = null;
 
         String query =
                 "SELECT * FROM " +
@@ -137,7 +137,7 @@ public class MessageDao implements Dao<Message>{
                 "LIMIT 1";
 
         try (Connection conn = DataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(query)){
+             PreparedStatement ps = conn.prepareStatement(query)) {
 
             ps.setLong(1, discordId);
 
@@ -155,7 +155,7 @@ public class MessageDao implements Dao<Message>{
                 attachmentLinks = result.getString(5);
             }
 
-            msgSpam = new Message(discordMsgId, discordId, timeCreated, messageContent, attachmentLinks);
+            msgSpam = new DiscordMessage(discordMsgId, discordId, timeCreated, messageContent, attachmentLinks);
 
         } catch (SQLException e) {
             log.error("Could not get latest message for spam detection.");
@@ -167,13 +167,12 @@ public class MessageDao implements Dao<Message>{
     }
 
     @Override
-    public void update(Message message) {
+    public void update(DiscordMessage message) {
 
     }
 
     @Override
-    public void delete(Message message) {
+    public void delete(DiscordMessage message) {
 
     }
-
 }

--- a/src/main/java/va/rembot/database/dao/StarMessageDao.java
+++ b/src/main/java/va/rembot/database/dao/StarMessageDao.java
@@ -6,6 +6,7 @@ import va.rembot.database.models.StarMessage;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
@@ -40,11 +41,11 @@ public class StarMessageDao implements Dao<StarMessage>{
 
             ps.setLong(1, MsgId);
 
-            var result = ps.executeQuery();
-            var discordMsgId = 0L;
-            var starAmount = 0;
-            var isSent = false;
-            var embedMsgId = 0L;
+            ResultSet result = ps.executeQuery();
+            long discordMsgId = 0L;
+            int starAmount = 0;
+            boolean isSent = false;
+            long embedMsgId = 0L;
 
             while (result.next()) {
                 discordMsgId = result.getLong(1);

--- a/src/main/java/va/rembot/database/dao/StrikeSpamDao.java
+++ b/src/main/java/va/rembot/database/dao/StrikeSpamDao.java
@@ -17,7 +17,7 @@ public class StrikeSpamDao implements Dao<StrikeSpam> {
         String query = "INSERT IGNORE INTO strikes_spam (discord_user_id, amount, most_recent_given) VALUES (?, 0, ?)";
 
         try (Connection conn = DataSource.getConnection();
-             PreparedStatement pStmt = conn.prepareStatement(query)){
+             PreparedStatement pStmt = conn.prepareStatement(query)) {
 
             pStmt.setLong(1, strikeSpam.discordId());
             pStmt.setTimestamp(2, strikeSpam.mostRecentStrike());
@@ -48,7 +48,7 @@ public class StrikeSpamDao implements Dao<StrikeSpam> {
         String query = "SELECT * FROM strikes_spam WHERE discord_user_id = ?";
 
         try (Connection conn = DataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(query)){
+             PreparedStatement ps = conn.prepareStatement(query)) {
 
             ps.setLong(1, discordId);
 
@@ -88,25 +88,6 @@ public class StrikeSpamDao implements Dao<StrikeSpam> {
 
         } catch (SQLException e) {
             log.error("Could not update strikeSpam with new amount and timestamp for spam detection.");
-            log.error("StrikeSpam details: amount {}, mostRecentStrike {}, discordId {}", strikeSpam.amount(), strikeSpam.mostRecentStrike(), strikeSpam.discordId());
-            log.error("Error: {}", e.getMessage());
-        }
-    }
-
-    public void updateAmountToZero(StrikeSpam strikeSpam) {
-
-        String query = "UPDATE strikes_spam SET amount = 0, most_recent_given = ? WHERE discord_user_id = ?";
-
-        try (Connection conn = DataSource.getConnection();
-             PreparedStatement ps = conn.prepareStatement(query)){
-
-            ps.setTimestamp(1, strikeSpam.mostRecentStrike());
-            ps.setLong(2, strikeSpam.discordId());
-
-            ps.executeUpdate();
-
-        } catch (SQLException e) {
-            log.error("Could not update strikeSpam to amount 0 and timestamp for spam detection.");
             log.error("StrikeSpam details: amount {}, mostRecentStrike {}, discordId {}", strikeSpam.amount(), strikeSpam.mostRecentStrike(), strikeSpam.discordId());
             log.error("Error: {}", e.getMessage());
         }

--- a/src/main/java/va/rembot/database/dao/StrikeSpamDao.java
+++ b/src/main/java/va/rembot/database/dao/StrikeSpamDao.java
@@ -4,10 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import va.rembot.database.DataSource;
 import va.rembot.database.models.StrikeSpam;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Timestamp;
+import java.sql.*;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,8 +52,8 @@ public class StrikeSpamDao implements Dao<StrikeSpam> {
 
             ps.setLong(1, discordId);
 
-            var result = ps.executeQuery();
-            var amount = 0;
+            ResultSet result = ps.executeQuery();
+            int amount = 0;
             Timestamp mostRecentGiven = null;
 
             while (result.next()) {

--- a/src/main/java/va/rembot/database/dao/UserDao.java
+++ b/src/main/java/va/rembot/database/dao/UserDao.java
@@ -6,6 +6,7 @@ import va.rembot.database.models.DiscordUser;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +17,7 @@ public class UserDao implements Dao<DiscordUser>{
     @Override
     public void create(DiscordUser user) {
 
-        var id = user.discordId();
+        long id = user.discordId();
         String query = "INSERT IGNORE INTO users (discord_user_id) VALUES (?)";
 
         try (Connection conn = DataSource.getConnection();
@@ -43,8 +44,8 @@ public class UserDao implements Dao<DiscordUser>{
 
             ps.setLong(1, id);
 
-            var result = ps.executeQuery();
-            var userId = 0L;
+            ResultSet result = ps.executeQuery();
+            long userId = 0L;
             while (result.next()) {
                 userId = result.getLong(1);
             }

--- a/src/main/java/va/rembot/database/models/DiscordMessage.java
+++ b/src/main/java/va/rembot/database/models/DiscordMessage.java
@@ -1,0 +1,7 @@
+package va.rembot.database.models;
+
+import java.sql.Timestamp;
+
+public record DiscordMessage(long discordMessageId, long discordId, Timestamp timeCreated, String messageContent, String attachmentsLinks) {
+
+}

--- a/src/main/java/va/rembot/database/models/Message.java
+++ b/src/main/java/va/rembot/database/models/Message.java
@@ -1,7 +1,0 @@
-package va.rembot.database.models;
-
-import java.sql.Timestamp;
-
-public record Message(long discordMessageId, long discordId, Timestamp timeCreated, String messageContent, String attachmentsLinks) {
-
-}

--- a/src/main/java/va/rembot/exceptions/MessageNotFoundException.java
+++ b/src/main/java/va/rembot/exceptions/MessageNotFoundException.java
@@ -4,5 +4,4 @@ public class MessageNotFoundException extends RuntimeException {
     public MessageNotFoundException(String message) {
         super(message);
     }
-
 }

--- a/src/main/java/va/rembot/exceptions/MessageNotFoundException.java
+++ b/src/main/java/va/rembot/exceptions/MessageNotFoundException.java
@@ -5,7 +5,4 @@ public class MessageNotFoundException extends RuntimeException {
         super(message);
     }
 
-    public MessageNotFoundException(String message, long messageId) {
-        super(message + " " + messageId);
-    }
 }

--- a/src/main/java/va/rembot/exceptions/StarMessageNotFoundException.java
+++ b/src/main/java/va/rembot/exceptions/StarMessageNotFoundException.java
@@ -5,7 +5,4 @@ public class StarMessageNotFoundException extends RuntimeException {
         super(message);
     }
 
-    public StarMessageNotFoundException(String message, long messageId) {
-        super(message + " " + messageId);
-    }
 }

--- a/src/main/java/va/rembot/lib/ModerationLib.java
+++ b/src/main/java/va/rembot/lib/ModerationLib.java
@@ -39,6 +39,7 @@ public class ModerationLib {
                             .sendMessageEmbeds(embed)
                             .and(event.getHook().deleteOriginal())
                             .queue();
+                    log.info("[banUsingSlashCommand] Banned: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
                             logError("banUsingSlashCommand",
@@ -73,6 +74,7 @@ public class ModerationLib {
                     event.getGuild().getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID)
                             .sendMessageEmbeds(embed)
                             .queue();
+                    log.info("[banGeneric] Banned: {} for reason: {}", targetUser, reason);
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
                             logError("banGeneric",
@@ -94,6 +96,7 @@ public class ModerationLib {
                             .sendMessage("**[USER KICK]**: " + usrSnowflake.getAsMention() + " <R:" + reason + "> [MOD:" + slashCommandUser.getAsMention() + "]")
                             .and(event.getHook().deleteOriginal())
                             .queue();
+                    log.info("[kickUsingSlashCommand] Kicked: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
                             logError("kickUsingSlashCommand",
@@ -129,6 +132,7 @@ public class ModerationLib {
                             .sendMessageEmbeds(embed)
                             .and(event.getHook().deleteOriginal())
                             .queue();
+                    log.info("[muteUsingSlashCommand] Muted: {} by moderator: {} reason: {}", targetUser, slashCommandUser, reason);
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
                             logError("muteUsingSlashCommand",
@@ -164,6 +168,7 @@ public class ModerationLib {
                             .sendMessageEmbeds(embed)
                             .and(event.getMessage().reply("Stop spamming strike: " + strikes + "/" + BotConfig.getAntiSpamStrikeAmountInt() + " 3 strikes = ban."))
                             .queue();
+                    log.info("[onMessageReceived] Spam detected, muted and strike given to {}", targetUsr);
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
                             logError("muteSpam",
@@ -185,6 +190,7 @@ public class ModerationLib {
                             .sendMessage("**[USER UNBAN]**: " + usrSnowflake.getAsMention() + " <R:" + reason + "> [MOD:" + slashCommandUser.getAsMention() + "]")
                             .and(event.getHook().deleteOriginal())
                             .queue();
+                    log.info("[unbanUsingSlashCommand] Unbanned: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
                             logError("unbanUsingSlashCommand",
@@ -228,6 +234,7 @@ public class ModerationLib {
                             .sendMessage("**[USER UNMUTE]**: " + targetUser.getAsMention() + " <R:" + reason + "> [MOD:" + slashCommandUser.getAsMention() + "]")
                             .and(event.getHook().deleteOriginal())
                             .queue();
+                    log.info("[unmuteUsingSlashCommand] Unmuted: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
                             logError("unmuteUsingSlashCommand",

--- a/src/main/java/va/rembot/lib/ModerationLib.java
+++ b/src/main/java/va/rembot/lib/ModerationLib.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import va.rembot.BotConfig;
 
@@ -31,36 +32,48 @@ public class ModerationLib {
 
         MessageEmbed embed = buildEmbedForBan(targetUser, reason, slashCommandUser);
 
-        event.getGuild()
-                .ban(usrSnowflake, 0, TimeUnit.MINUTES)
-                .reason(reason)
-                .queue(success -> {
-                    event.getGuild().getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID)
-                            .sendMessageEmbeds(embed)
-                            .and(event.getHook().deleteOriginal())
-                            .queue();
-                    log.info("[banUsingSlashCommand] Banned: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
-                }, new ErrorHandler()
-                        .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logError("banUsingSlashCommand",
-                                    "Bot doesn't have enough permissions to ban the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
-                                    "ban",
-                                    slashCommandUser,
-                                    targetUser);
-                            event.getHook()
-                                    .editOriginal("Failed to ban that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
-                                    .queue();
-                        })
-                        .handle(ErrorResponse.UNKNOWN_USER, e -> {
-                            logError("banUsingSlashCommand",
-                                    "Dont know who the target user is (Unknown user).",
-                                    "ban",
-                                    slashCommandUser,
-                                    targetUser);
-                            event.getHook()
-                                    .editOriginal("I can't find the person you are trying to ban (unknown user)." + slashCommandUser.getAsMention())
-                                    .queue();
-                        }));
+        try {
+            event.getGuild()
+                    .ban(usrSnowflake, 0, TimeUnit.MINUTES)
+                    .reason(reason)
+                    .queue(success -> {
+                        event.getGuild().getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID)
+                                .sendMessageEmbeds(embed)
+                                .and(event.getHook().deleteOriginal())
+                                .queue();
+                        log.info("[banUsingSlashCommand] Banned: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
+                    }, new ErrorHandler()
+                            .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
+                                logError("banUsingSlashCommand",
+                                        "Bot doesn't have enough permissions to ban the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                        "ban",
+                                        slashCommandUser,
+                                        targetUser);
+                                event.getHook()
+                                        .editOriginal("Failed to ban that user because I don't have sufficient perms (most likely need a role with higher permissions than the target).")
+                                        .queue();
+                            })
+                            .handle(ErrorResponse.UNKNOWN_USER, e -> {
+                                logError("banUsingSlashCommand",
+                                        "Dont know who the target user is (Unknown user).",
+                                        "ban",
+                                        slashCommandUser,
+                                        targetUser);
+                                event.getHook()
+                                        .editOriginal("I can't find the person you are trying to ban (unknown user).")
+                                        .queue();
+                            }));
+        } catch (HierarchyException e) {
+            event.getHook()
+                    .editOriginal("Can't ban that person they have more (or same) perms than me!")
+                    .queue(success -> {
+                        logError("banUsingSlashCommand",
+                                "Bot doesn't have enough permissions to ban the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                "ban",
+                                slashCommandUser,
+                                targetUser);
+                    });
+        }
     }
 
     public static void banGeneric(MessageReceivedEvent event, UserSnowflake usrSnowflake, String reason, User targetUser) {
@@ -88,72 +101,96 @@ public class ModerationLib {
 
     public static void kickUsingSlashCommand(SlashCommandInteractionEvent event, UserSnowflake usrSnowflake, String reason, User slashCommandUser, User targetUser) {
 
-        event.getGuild()
-                .kick(usrSnowflake)
-                .reason(reason)
-                .queue(success -> {
-                    event.getGuild().getChannelById(TextChannel.class , BotConfig.LOG_CHANNEL_ID)
-                            .sendMessage("**[USER KICK]**: " + usrSnowflake.getAsMention() + " <R:" + reason + "> [MOD:" + slashCommandUser.getAsMention() + "]")
-                            .and(event.getHook().deleteOriginal())
-                            .queue();
-                    log.info("[kickUsingSlashCommand] Kicked: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
-                }, new ErrorHandler()
-                        .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logError("kickUsingSlashCommand",
-                                    "Bot doesn't have enough permissions to kick the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
-                                    "kick",
-                                    slashCommandUser,
-                                    targetUser);
-                            event.getHook()
-                                    .editOriginal("Failed to kick that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
-                                    .queue();
-                        })
-                        .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
-                            logError("kickUsingSlashCommand",
-                                    "The member that was being kicked was already removed from this server before finishing the kicking task.",
-                                    "kick",
-                                    slashCommandUser,
-                                    targetUser);
-                            event.getHook()
-                                    .editOriginal("The user you tried to kick was already removed from this server." + slashCommandUser.getAsMention())
-                                    .queue();
-                        }));
+        try {
+            event.getGuild()
+                    .kick(usrSnowflake)
+                    .reason(reason)
+                    .queue(success -> {
+                        event.getGuild().getChannelById(TextChannel.class , BotConfig.LOG_CHANNEL_ID)
+                                .sendMessage("**[USER KICK]**: " + usrSnowflake.getAsMention() + " <R:" + reason + "> [MOD:" + slashCommandUser.getAsMention() + "]")
+                                .and(event.getHook().deleteOriginal())
+                                .queue();
+                        log.info("[kickUsingSlashCommand] Kicked: {} by moderator: {} for reason: {}", targetUser, slashCommandUser, reason);
+                    }, new ErrorHandler()
+                            .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
+                                logError("kickUsingSlashCommand",
+                                        "Bot doesn't have enough permissions to kick the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                        "kick",
+                                        slashCommandUser,
+                                        targetUser);
+                                event.getHook()
+                                        .editOriginal("Failed to kick that user because I don't have sufficient perms (most likely need a role with higher permissions than the target).")
+                                        .queue();
+                            })
+                            .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
+                                logError("kickUsingSlashCommand",
+                                        "The member that was being kicked was already removed from this server before finishing the kicking task.",
+                                        "kick",
+                                        slashCommandUser,
+                                        targetUser);
+                                event.getHook()
+                                        .editOriginal("The user you tried to kick was already removed from this server.")
+                                        .queue();
+                            }));
+        } catch (HierarchyException e) {
+            event.getHook()
+                    .editOriginal("Can't kick that person they have more (or same) perms than me!")
+                    .queue(success -> {
+                        logError("kickUsingSlashCommand",
+                                "Bot doesn't have enough permissions to kick the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                "kick",
+                                slashCommandUser,
+                                targetUser);
+                    });
+        }
     }
 
     public static void muteUsingSlashCommand(SlashCommandInteractionEvent event, UserSnowflake usrSnowflake, String reason, int muteTimeTotalMinutes, User slashCommandUser, User targetUser) {
 
         MessageEmbed embed = buildEmbedForMute(targetUser, reason, slashCommandUser, muteTimeTotalMinutes);
 
-        event.getGuild()
-                .timeoutFor(usrSnowflake, Duration.ofMinutes(muteTimeTotalMinutes))
-                .reason(reason)
-                .queue(success -> {
-                    event.getGuild().getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID)
-                            .sendMessageEmbeds(embed)
-                            .and(event.getHook().deleteOriginal())
-                            .queue();
-                    log.info("[muteUsingSlashCommand] Muted: {} by moderator: {} reason: {}", targetUser, slashCommandUser, reason);
-                }, new ErrorHandler()
-                        .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logError("muteUsingSlashCommand",
-                                    "Bot doesn't have enough permissions to mute the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
-                                    "mute",
-                                    slashCommandUser,
-                                    targetUser);
-                            event.getHook()
-                                    .editOriginal("Failed to muted that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
-                                    .queue();
-                        })
-                        .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
-                            logError("muteUsingSlashCommand",
-                                    "The member that was being muted was already removed from this server before finishing the muting task.",
-                                    "mute",
-                                    slashCommandUser,
-                                    targetUser);
-                            event.getHook()
-                                    .editOriginal("The user you tried to mute was already removed from this server." + slashCommandUser.getAsMention())
-                                    .queue();
-                        }));
+        try {
+            event.getGuild()
+                    .timeoutFor(usrSnowflake, Duration.ofMinutes(muteTimeTotalMinutes))
+                    .reason(reason)
+                    .queue(success -> {
+                        event.getGuild().getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID)
+                                .sendMessageEmbeds(embed)
+                                .and(event.getHook().deleteOriginal())
+                                .queue();
+                        log.info("[muteUsingSlashCommand] Muted: {} by moderator: {} reason: {}", targetUser, slashCommandUser, reason);
+                    }, new ErrorHandler()
+                            .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
+                                logError("muteUsingSlashCommand",
+                                        "Bot doesn't have enough permissions to mute the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                        "mute",
+                                        slashCommandUser,
+                                        targetUser);
+                                event.getHook()
+                                        .editOriginal("Failed to muted that user because I don't have sufficient perms (most likely need a role with higher permissions than the target).")
+                                        .queue();
+                            })
+                            .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
+                                logError("muteUsingSlashCommand",
+                                        "The member that was being muted was already removed from this server before finishing the muting task.",
+                                        "mute",
+                                        slashCommandUser,
+                                        targetUser);
+                                event.getHook()
+                                        .editOriginal("The user you tried to mute was already removed from this server.")
+                                        .queue();
+                            }));
+        } catch (HierarchyException e) {
+            event.getHook()
+                    .editOriginal("Can't mute that person they have more (or same) perms as me!")
+                    .queue(success -> {
+                        logError("muteUsingSlashCommand",
+                                "Bot doesn't have enough permissions to mute the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                "mute",
+                                slashCommandUser,
+                                targetUser);
+                    });
+        }
     }
 
     public static void muteSpam(MessageReceivedEvent event, UserSnowflake usrSnowflake, String reason, int strikes, User targetUsr) {
@@ -199,7 +236,7 @@ public class ModerationLib {
                                     slashCommandUser,
                                     targetUser);
                             event.getHook()
-                                    .editOriginal("Failed to unban that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
+                                    .editOriginal("Failed to unban that user because I don't have sufficient perms (most likely need a role with higher permissions than the target).")
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_BAN, e -> {
@@ -209,7 +246,7 @@ public class ModerationLib {
                                     slashCommandUser,
                                     targetUser);
                             event.getHook()
-                                    .editOriginal("Failed to unban that user because I think that user is not banned (the ban is unknown to me)." + slashCommandUser.getAsMention())
+                                    .editOriginal("Failed to unban that user because I think that user is not banned (the ban is unknown to me).")
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_USER, e -> {
@@ -219,12 +256,12 @@ public class ModerationLib {
                                     slashCommandUser,
                                     targetUser);
                             event.getHook()
-                                    .editOriginal("I can't find the person you are trying to unban (unknown user)." + slashCommandUser.getAsMention())
+                                    .editOriginal("I can't find the person you are trying to unban (unknown user).")
                                     .queue();
                         }));
     }
 
-    public static void unmuteUsingSlashCommand(SlashCommandInteractionEvent event, UserSnowflake usrSnowflake, String reason, User slashCommandUser, User targetUser) {
+    public static void unmuteUsingSlashCommand(SlashCommandInteractionEvent event, String reason, User slashCommandUser, User targetUser) {
 
         event.getGuild()
                 .getMemberById(targetUser.getId())
@@ -243,7 +280,7 @@ public class ModerationLib {
                                     slashCommandUser,
                                     targetUser);
                             event.getHook()
-                                    .editOriginal("Failed to unmute that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
+                                    .editOriginal("Failed to unmute that user because I don't have sufficient perms (most likely need a role with higher permissions than the target).")
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
@@ -253,7 +290,7 @@ public class ModerationLib {
                                     slashCommandUser,
                                     targetUser);
                             event.getHook()
-                                    .editOriginal("Failed to unmute that user because they were removed from the guild before the unmuting task finished." + slashCommandUser.getAsMention())
+                                    .editOriginal("Failed to unmute that user because they were removed from the guild before the unmuting task finished.")
                                     .queue();
                         }));
     }

--- a/src/main/java/va/rembot/lib/ModerationLib.java
+++ b/src/main/java/va/rembot/lib/ModerationLib.java
@@ -15,7 +15,6 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
-/// Central class for accessing moderation methods, also to customize them (for example the embed messages).
 public class ModerationLib {
 
     private static final int EMBED_MESSAGE_COLOR = 0xbb0a1e;
@@ -30,7 +29,7 @@ public class ModerationLib {
 
     public static void banUsingSlashCommand(SlashCommandInteractionEvent event, UserSnowflake usrSnowflake, String reason, User slashCommandUser, User targetUser) {
 
-        var embed = buildEmbedForBan(targetUser, reason, slashCommandUser);
+        MessageEmbed embed = buildEmbedForBan(targetUser, reason, slashCommandUser);
 
         event.getGuild()
                 .ban(usrSnowflake, 0, TimeUnit.MINUTES)
@@ -42,13 +41,21 @@ public class ModerationLib {
                             .queue();
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logBanErrorSlashCommand("Bot doesn't have enough permissions to ban the target user. (Bot probably has a lower or same discord role hierarchy as the target).", slashCommandUser, targetUser);
+                            logError("banUsingSlashCommand",
+                                    "Bot doesn't have enough permissions to ban the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                    "ban",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("Failed to ban that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_USER, e -> {
-                            logBanErrorSlashCommand("Dont know who the target user is (Unknown user).", slashCommandUser, targetUser);
+                            logError("banUsingSlashCommand",
+                                    "Dont know who the target user is (Unknown user).",
+                                    "ban",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("I can't find the person you are trying to ban (unknown user)." + slashCommandUser.getAsMention())
                                     .queue();
@@ -57,7 +64,7 @@ public class ModerationLib {
 
     public static void banGeneric(MessageReceivedEvent event, UserSnowflake usrSnowflake, String reason, User targetUser) {
 
-        var embed = buildEmbedForBanGeneric(targetUser, reason);
+        MessageEmbed embed = buildEmbedForBanGeneric(targetUser, reason);
 
         event.getGuild()
                 .ban(usrSnowflake, 0, TimeUnit.MINUTES)
@@ -68,10 +75,12 @@ public class ModerationLib {
                             .queue();
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logBanErrorGeneric("Bot doesn't have enough permissions to ban the target user. (Bot probably has a lower or same discord role hierarchy as the target).");
+                            logError("banGeneric",
+                                    "Bot doesn't have enough permissions to ban the target user. (Bot probably has a lower or same discord role hierarchy as the target).");
                         })
                         .handle(ErrorResponse.UNKNOWN_USER, e -> {
-                            logBanErrorGeneric("Dont know who the target user is (Unknown user).");
+                            logError("banGeneric",
+                                    "Dont know who the target user is (Unknown user).");
                         }));
     }
 
@@ -87,13 +96,21 @@ public class ModerationLib {
                             .queue();
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logKickErrorSlashCommand("Bot doesn't have enough permissions to kick the target user. (Bot probably has a lower or same discord role hierarchy as the target).", slashCommandUser, targetUser);
+                            logError("kickUsingSlashCommand",
+                                    "Bot doesn't have enough permissions to kick the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                    "kick",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("Failed to kick that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
-                            logKickErrorSlashCommand("The member that was being kicked was already removed from this server before finishing the kicking task.", slashCommandUser, targetUser);
+                            logError("kickUsingSlashCommand",
+                                    "The member that was being kicked was already removed from this server before finishing the kicking task.",
+                                    "kick",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("The user you tried to kick was already removed from this server." + slashCommandUser.getAsMention())
                                     .queue();
@@ -102,7 +119,7 @@ public class ModerationLib {
 
     public static void muteUsingSlashCommand(SlashCommandInteractionEvent event, UserSnowflake usrSnowflake, String reason, int muteTimeTotalMinutes, User slashCommandUser, User targetUser) {
 
-        var embed = buildEmbedForMute(targetUser, reason, slashCommandUser, muteTimeTotalMinutes);
+        MessageEmbed embed = buildEmbedForMute(targetUser, reason, slashCommandUser, muteTimeTotalMinutes);
 
         event.getGuild()
                 .timeoutFor(usrSnowflake, Duration.ofMinutes(muteTimeTotalMinutes))
@@ -114,13 +131,21 @@ public class ModerationLib {
                             .queue();
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logMuteErrorSlashCommand("Bot doesn't have enough permissions to mute the target user. (Bot probably has a lower or same discord role hierarchy as the target).", slashCommandUser, targetUser);
+                            logError("muteUsingSlashCommand",
+                                    "Bot doesn't have enough permissions to mute the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                    "mute",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("Failed to muted that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
-                            logMuteErrorSlashCommand("The member that was being muted was already removed from this server before finishing the muting task.", slashCommandUser, targetUser);
+                            logError("muteUsingSlashCommand",
+                                    "The member that was being muted was already removed from this server before finishing the muting task.",
+                                    "mute",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("The user you tried to mute was already removed from this server." + slashCommandUser.getAsMention())
                                     .queue();
@@ -129,7 +154,7 @@ public class ModerationLib {
 
     public static void muteSpam(MessageReceivedEvent event, UserSnowflake usrSnowflake, String reason, int strikes, User targetUsr) {
 
-        var embed = buildEmbedForMuteSpam(targetUsr, BotConfig.getAntiSpamMuteAmountInt());
+        MessageEmbed embed = buildEmbedForMuteSpam(targetUsr, BotConfig.getAntiSpamMuteAmountInt());
 
         event.getGuild()
                 .timeoutFor(usrSnowflake, Duration.ofMinutes(BotConfig.getAntiSpamMuteAmountInt()))
@@ -141,10 +166,12 @@ public class ModerationLib {
                             .queue();
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logMuteErrorGeneric("Bot doesn't have enough permissions to mute the target user. (Bot probably has a lower or same discord role hierarchy as the target).");
+                            logError("muteSpam",
+                                    "Bot doesn't have enough permissions to mute the target user. (Bot probably has a lower or same discord role hierarchy as the target).");
                         })
                         .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
-                            logMuteErrorGeneric("The member that was being muted was already removed from this server before finishing the muting task.");
+                            logError("muteSpam",
+                                    "The member that was being muted was already removed from this server before finishing the muting task.");
                         }));
     }
 
@@ -160,19 +187,31 @@ public class ModerationLib {
                             .queue();
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logUnbanErrorSlashCommand("Bot doesn't have enough permissions to unban the target user. (Bot probably has a lower or same discord role hierarchy as the target).", slashCommandUser, targetUser);
+                            logError("unbanUsingSlashCommand",
+                                    "Bot doesn't have enough permissions to unban the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                    "unban",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("Failed to unban that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_BAN, e -> {
-                            logUnbanErrorSlashCommand("Couldn't unban that user because the ban is unknown (possibly not banned?).", slashCommandUser, targetUser);
+                            logError("unbanUsingSlashCommand",
+                                    "Couldn't unban that user because the ban is unknown (possibly not banned?).",
+                                    "unban",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("Failed to unban that user because I think that user is not banned (the ban is unknown to me)." + slashCommandUser.getAsMention())
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_USER, e -> {
-                            logUnbanErrorSlashCommand("Dont know who the target user is (Unknown user).", slashCommandUser, targetUser);
+                            logError("unbanUsingSlashCommand",
+                                    "Dont know who the target user is (Unknown user).",
+                                    "unban",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("I can't find the person you are trying to unban (unknown user)." + slashCommandUser.getAsMention())
                                     .queue();
@@ -191,13 +230,21 @@ public class ModerationLib {
                             .queue();
                 }, new ErrorHandler()
                         .handle(ErrorResponse.MISSING_PERMISSIONS, e -> {
-                            logUnmuteErrorSlashCommand("Bot doesn't have enough permissions to unmute the target user. (Bot probably has a lower or same discord role hierarchy as the target).", slashCommandUser, targetUser);
+                            logError("unmuteUsingSlashCommand",
+                                    "Bot doesn't have enough permissions to unmute the target user. (Bot probably has a lower or same discord role hierarchy as the target).",
+                                    "unmute",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("Failed to unmute that user because I don't have sufficient perms (most likely need a role with higher permissions than the target)." + slashCommandUser.getAsMention())
                                     .queue();
                         })
                         .handle(ErrorResponse.UNKNOWN_MEMBER, e -> {
-                            logUnmuteErrorSlashCommand("The target user was removed from the guild before bot could unmute them.", slashCommandUser, targetUser);
+                            logError("unmuteUsingSlashCommand",
+                                    "The target user was removed from the guild before bot could unmute them.",
+                                    "unmute",
+                                    slashCommandUser,
+                                    targetUser);
                             event.getHook()
                                     .editOriginal("Failed to unmute that user because they were removed from the guild before the unmuting task finished." + slashCommandUser.getAsMention())
                                     .queue();
@@ -257,37 +304,12 @@ public class ModerationLib {
         return embed.build();
     }
 
-    private static void logBanErrorSlashCommand(String error, User slashCommandUser, User targetUser) {
-        log.error(error);
-        log.error("{} tried to ban {}", slashCommandUser, targetUser);
+    private static void logError(String methodName, String error) {
+        log.error("[{}] {}", methodName, error);
     }
 
-    private static void logBanErrorGeneric(String error) {
-        log.error(error);
+    private static void logError(String methodName, String error, String commandBeingUsed, User slashCommandUser, User targetUser) {
+        log.error("[{}] {}", methodName, error);
+        log.error("[{}] {} tried to {} {}", methodName, slashCommandUser, commandBeingUsed, targetUser);
     }
-
-    private static void logKickErrorSlashCommand(String error, User slashCommandUser, User targetUser) {
-        log.error(error);
-        log.error("{} tried to kick {}", slashCommandUser, targetUser);
-    }
-
-    private static void logMuteErrorSlashCommand(String error, User slashCommandUser, User targetUser) {
-        log.error(error);
-        log.error("{} tried to mute {}", slashCommandUser, targetUser);
-    }
-
-    private static void logMuteErrorGeneric(String error) {
-        log.error(error);
-    }
-
-    private static void logUnbanErrorSlashCommand(String error, User slashCommandUser, User targetUser) {
-        log.error(error);
-        log.error("{} tried to unban {}", slashCommandUser, targetUser);
-    }
-
-    private static void logUnmuteErrorSlashCommand(String error, User slashCommandUser, User targetUser) {
-        log.error(error);
-        log.error("{} tried to unmute {}", slashCommandUser, targetUser);
-    }
-
 }

--- a/src/main/java/va/rembot/moderation/AntiSpamFilter.java
+++ b/src/main/java/va/rembot/moderation/AntiSpamFilter.java
@@ -78,7 +78,6 @@ public class AntiSpamFilter extends ListenerAdapter {
         if (timeLastMsgCreatedSeconds - timeFirstMsgCreatedSeconds <= ANTI_SPAM_TIME_AMOUNT && timeLastMsgCreatedSeconds != timeFirstMsgCreatedSeconds) {
 
             if (timeMsgSentNowSeconds - timeLastTimeStrikeGivenSeconds > 5) {
-                log.debug("[onMessageReceived] spam detected, strike given to {}", msg.getAuthor());
                 strikes++;
                 strikeSpamDao.update(new StrikeSpam(discordId, strikes, new Timestamp(msgCreated)));
 

--- a/src/main/java/va/rembot/moderation/AntiSpamFilter.java
+++ b/src/main/java/va/rembot/moderation/AntiSpamFilter.java
@@ -1,6 +1,9 @@
 package va.rembot.moderation;
 
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Message.Attachment;
 import net.dv8tion.jda.api.entities.UserSnowflake;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -9,51 +12,46 @@ import va.rembot.database.dao.MessageDao;
 import va.rembot.database.dao.StrikeSpamDao;
 import va.rembot.database.dao.UserDao;
 import va.rembot.database.models.DiscordUser;
-import va.rembot.database.models.Message;
+import va.rembot.database.models.DiscordMessage;
 import va.rembot.database.models.StrikeSpam;
 import va.rembot.exceptions.MessageSpamNotFoundException;
 import va.rembot.exceptions.StrikeSpamNotFoundException;
 import va.rembot.lib.ModerationLib;
 
 import java.sql.*;
+import java.time.Instant;
 
 @Slf4j
-/// a user gets 3 strikes in total for spamming after third they get banned, ALL strikes expire after a week of last strike.
 public class AntiSpamFilter extends ListenerAdapter {
 
-    private final int ANTI_SPAM_TIME_AMOUNT = BotConfig.getAntiSpamTimeAmountInt();
-    private final int ANTI_SPAM_STRIKE_AMOUNT = BotConfig.getAntiSpamStrikeAmountInt();
+    private static final int ANTI_SPAM_TIME_AMOUNT = BotConfig.getAntiSpamTimeAmountInt();
+    private static final int ANTI_SPAM_STRIKE_AMOUNT = BotConfig.getAntiSpamStrikeAmountInt();
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
-
-        var usrDao = new UserDao();
-        var strikeSpamDao = new StrikeSpamDao();
-        var messageDao = new MessageDao();
-
-        var msg = event.getMessage();
-        var msgCreated = msg.getTimeCreated().toInstant().toEpochMilli();
-        var user = event.getMember();
-        var discordId = event.getMember().getIdLong();
-        var usrSnowflake = UserSnowflake.fromId(discordId);
-        var discordMsgId = event.getMessageIdLong();
-        var msgContent = msg.getContentRaw();
-
-        Timestamp timeFirstMsgCreated;
-        Timestamp timeLastMsgCreated;
-
-        String attachmentLinks = "";
-
-        for (var file : msg.getAttachments()) {
-             attachmentLinks += file.getUrl() + " ";
-        }
-
-        usrDao.create(new DiscordUser(discordId));
-        messageDao.create(new Message(discordMsgId, discordId, new Timestamp(msgCreated), msgContent,  attachmentLinks));
-
         if (ModerationLib.isMod(event.getMember())) return;
 
+        UserDao userDao = new UserDao();
+        StrikeSpamDao strikeSpamDao = new StrikeSpamDao();
+        MessageDao messageDao = new MessageDao();
+
+        Message msg = event.getMessage();
+        long msgCreated = msg.getTimeCreated().toInstant().toEpochMilli();
+        long discordId = event.getMember().getIdLong();
+        long discordMsgId = event.getMessageIdLong();
+        UserSnowflake usrSnowflake = UserSnowflake.fromId(discordId);
+        Member user = event.getMember();
+        Timestamp timeFirstMsgCreated;
+        Timestamp timeLastMsgCreated;
+        String msgContent = msg.getContentRaw();
+        StringBuilder attachmentLinks = new StringBuilder();
+
+        for (Attachment file : msg.getAttachments())
+             attachmentLinks.append(file.getUrl()).append(" ");
+
+        userDao.create(new DiscordUser(discordId));
+        messageDao.create(new DiscordMessage(discordMsgId, discordId, new Timestamp(msgCreated), msgContent, attachmentLinks.toString()));
         strikeSpamDao.create(new StrikeSpam(discordId, 0, new Timestamp(msgCreated)));
 
         timeFirstMsgCreated = messageDao
@@ -63,8 +61,7 @@ public class AntiSpamFilter extends ListenerAdapter {
                 .getLatest(discordId)
                 .orElseThrow(() -> new MessageSpamNotFoundException("messageDao could not find latest entry for user with discord id: " + discordId)).timeCreated();
 
-        var strikes = 0;
-
+        int strikes;
         Timestamp lastTimeStrikeGiven;
 
         strikes = strikeSpamDao
@@ -74,30 +71,23 @@ public class AntiSpamFilter extends ListenerAdapter {
                 .getAmount(discordId)
                 .orElseThrow(() -> new StrikeSpamNotFoundException("strikeSpamDao could not find lastTimeStrikeGiven for user with discord id: " + discordId)).mostRecentStrike();
 
-        var timeFirstMsgCreatedSeconds = timeFirstMsgCreated.toInstant().getEpochSecond();
-        var timeLastMsgCreatedSeconds = timeLastMsgCreated.toInstant().getEpochSecond();
+        long timeFirstMsgCreatedSeconds = timeFirstMsgCreated.toInstant().getEpochSecond();
+        long timeLastMsgCreatedSeconds = timeLastMsgCreated.toInstant().getEpochSecond();
+        long timeLastTimeStrikeGiven = lastTimeStrikeGiven.toInstant().getEpochSecond();
+        long timeMsgSentNow = new Timestamp(msgCreated).toInstant().getEpochSecond();
 
-        // If the time between the latest msg and the first msg of the bunch (set by the user, defaults to 5). Is less
-        // than our threshold we count that as spam.
-        if (timeLastMsgCreatedSeconds - timeFirstMsgCreatedSeconds <= ANTI_SPAM_TIME_AMOUNT && timeLastMsgCreatedSeconds != timeFirstMsgCreatedSeconds){
+        if (timeLastMsgCreatedSeconds - timeFirstMsgCreatedSeconds <= ANTI_SPAM_TIME_AMOUNT && timeLastMsgCreatedSeconds != timeFirstMsgCreatedSeconds) {
 
-            // Prevent bot spam muting user by leaving at least 5 secs between now and last time strike was given.
-            if (new Timestamp(msgCreated).toInstant().getEpochSecond() - lastTimeStrikeGiven.toInstant().getEpochSecond() > 5) {
+            if (timeMsgSentNow - timeLastTimeStrikeGiven > 5) {
+                log.debug("[onMessageReceived] spam detected, strike given to {}", msg.getAuthor());
                 strikes++;
-
                 strikeSpamDao.update(new StrikeSpam(discordId, strikes, new Timestamp(msgCreated)));
 
-                // If strikes are below/equal our accepted value give strike, else ban. Set strikes to 0 if they ever
-                // get unbanned that this procedure would still work with them.
-                if (strikes <= ANTI_SPAM_STRIKE_AMOUNT) {
-
+                if (strikes < ANTI_SPAM_STRIKE_AMOUNT)
                     ModerationLib.muteSpam(event, usrSnowflake, "Spamming", strikes, user.getUser());
-                } else {
-
+                else {
                     ModerationLib.banGeneric(event, usrSnowflake, "Spamming", user.getUser());
-                    
-                    // Set strikes to 0 after banning, could delete too but chose this route.
-                    strikeSpamDao.updateAmountToZero(new StrikeSpam(discordId, 0, new Timestamp(msgCreated)));
+                    strikeSpamDao.update(new StrikeSpam(discordId, 0, new Timestamp(msgCreated)));
                 }
             }
         }

--- a/src/main/java/va/rembot/moderation/AntiSpamFilter.java
+++ b/src/main/java/va/rembot/moderation/AntiSpamFilter.java
@@ -72,12 +72,12 @@ public class AntiSpamFilter extends ListenerAdapter {
 
         long timeFirstMsgCreatedSeconds = timeFirstMsgCreated.toInstant().getEpochSecond();
         long timeLastMsgCreatedSeconds = timeLastMsgCreated.toInstant().getEpochSecond();
-        long timeLastTimeStrikeGiven = lastTimeStrikeGiven.toInstant().getEpochSecond();
-        long timeMsgSentNow = new Timestamp(msgCreated).toInstant().getEpochSecond();
+        long timeLastTimeStrikeGivenSeconds = lastTimeStrikeGiven.toInstant().getEpochSecond();
+        long timeMsgSentNowSeconds = new Timestamp(msgCreated).toInstant().getEpochSecond();
 
         if (timeLastMsgCreatedSeconds - timeFirstMsgCreatedSeconds <= ANTI_SPAM_TIME_AMOUNT && timeLastMsgCreatedSeconds != timeFirstMsgCreatedSeconds) {
 
-            if (timeMsgSentNow - timeLastTimeStrikeGiven > 5) {
+            if (timeMsgSentNowSeconds - timeLastTimeStrikeGivenSeconds > 5) {
                 log.debug("[onMessageReceived] spam detected, strike given to {}", msg.getAuthor());
                 strikes++;
                 strikeSpamDao.update(new StrikeSpam(discordId, strikes, new Timestamp(msgCreated)));

--- a/src/main/java/va/rembot/moderation/AntiSpamFilter.java
+++ b/src/main/java/va/rembot/moderation/AntiSpamFilter.java
@@ -19,7 +19,6 @@ import va.rembot.exceptions.StrikeSpamNotFoundException;
 import va.rembot.lib.ModerationLib;
 
 import java.sql.*;
-import java.time.Instant;
 
 @Slf4j
 public class AntiSpamFilter extends ListenerAdapter {

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -187,7 +187,7 @@ public class BannedWordsFilter extends ListenerAdapter {
     private List<String> getCombinedWords(List<String> substitutedMsg) {
 
         List<String> combinedWordsList = new ArrayList<>();
-        String combinedWord;
+        StringBuilder combinedWord = new StringBuilder();
         int comboWordIndexStart = 0;
         int comboWordIndexNext = 1;
 
@@ -199,11 +199,11 @@ public class BannedWordsFilter extends ListenerAdapter {
             log.debug("[getCombinedWords] Combo word ONE: {}", substitutedMsg.get(comboWordIndexStart));
             log.debug("[getCombinedWords] Combo word TWO: {}", substitutedMsg.get(comboWordIndexNext));
 
-            combinedWord = substitutedMsg.get(comboWordIndexStart) + " " + substitutedMsg.get(comboWordIndexNext);
-            combinedWordsList.add(combinedWord);
+            combinedWord.append(substitutedMsg.get(comboWordIndexStart)).append(" ").append(substitutedMsg.get(comboWordIndexNext));
+            combinedWordsList.add(combinedWord.toString());
 
             log.debug("[getCombinedWords] Combined word: {}", combinedWord);
-            log.debug("[getCombinedWords] Combo word being build: {}", combinedWordsList);
+            log.debug("[getCombinedWords] Combo words (list) being build: {}", combinedWordsList);
 
             comboWordIndexStart += 1;
             comboWordIndexNext += 1;

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -27,9 +27,12 @@ public class BannedWordsFilter extends ListenerAdapter {
         String msg = event.getMessage().getContentRaw();
         msg = msg.replaceAll("https?://\\S+", "");
         String msgEmojisConvertedToChars = EmojiHelper.emojiToChar(msg);
-        String msgEmojisConvertedToCharsTrimmed = msgEmojisConvertedToChars.replace(" ", "");
+        String msgEmojisConvertedToCharsTrimmed = "";
 
-        String msgTotal = (msgEmojisConvertedToChars + " " + msgEmojisConvertedToCharsTrimmed);
+        if (EmojiHelper.hasLetterEmojiInMessage(msg))
+            msgEmojisConvertedToCharsTrimmed = msgEmojisConvertedToChars.replace(" ", "");
+
+        String msgTotal = (msgEmojisConvertedToChars + " " + msgEmojisConvertedToCharsTrimmed).trim();
 
         for (Character c : FILTERED_SPECIAL_CHARS)
             msgTotal = msgTotal.replace(c.toString(), "");
@@ -39,7 +42,11 @@ public class BannedWordsFilter extends ListenerAdapter {
                 .filter(word -> !word.isEmpty())
                 .toList().toArray(new String[0]);
 
-        List<String> combinedWords = getCombinedWords(Arrays.stream(msgTotalArray).toList());
+        String[] msgTotalArrayBeforeSubstituting = Arrays.stream(msgTotal.split(" "))
+                .filter(word -> !word.isEmpty())
+                .toList().toArray(new String[0]);
+
+        List<String> combinedWords = getCombinedWords(Arrays.stream(msgTotalArrayBeforeSubstituting).toList());
 
         log.debug("[onMessageReceived] msg: {}", msg);
         log.debug("[onMessageReceived] msgEmojisConvertedToChars: {}", msgEmojisConvertedToChars);
@@ -87,12 +94,12 @@ public class BannedWordsFilter extends ListenerAdapter {
 //            }
 
         List<String> substitutedMsg = substitute(msgTotalArray);
-        List<String> combinedWordsList = getCombinedWords(substitutedMsg);
+        combinedWords = getCombinedWords(substitutedMsg);
 
         log.debug("[onMessageReceived] substitutedMsg: {}", substitutedMsg);
-        log.debug("[onMessageReceived] combinedWordsList: {}", combinedWordsList);
+        log.debug("[onMessageReceived] combinedWords: {}", combinedWords);
 
-        checkMessageForBannedWordExcludingWhitelisted(combinedWordsList, substitutedMsg, event, msg);
+        checkMessageForBannedWordExcludingWhitelisted(combinedWords, substitutedMsg, event, msg);
     }
 
     private void deleteMsg(MessageReceivedEvent event, String msg, String bannedWord){
@@ -107,7 +114,7 @@ public class BannedWordsFilter extends ListenerAdapter {
 
     private boolean hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(List<String> combinedWordsList, MessageReceivedEvent event, String msg) {
 
-        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] Checking for banned words before substituting combined words variant");
+        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] Checking for banned words before substituting");
 
         String newMsg = msg;
         List<String> newMsgAsList;

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -10,9 +10,6 @@ import va.rembot.lib.ModerationLib;
 import java.util.*;
 
 @Slf4j
-///banned words get auto deleted, we dont do any moderation (ban/kick...) atm.
-///first we check if we can find the banned word normally in the string (best case scenario/fastest)
-///afterwards we substitute characters to again find the banned word (only if there is a sub char in original msg)
 public class BannedWordsFilter extends ListenerAdapter {
 
     private static final List<String> LIST_BANNED_WORDS = Arrays.stream(BotConfig.BANNED_WORDS_ARRAY).toList();
@@ -20,7 +17,7 @@ public class BannedWordsFilter extends ListenerAdapter {
     private static final Map<Character, List<Character>> SUBS_PER_CHAR = getSubsForChars();
     private static final Set<Character> DOUBLE_ANTI_CENSOR_CHARS = getPotentialDoubleAntiCensor();
     private static final Set<Character> FILTERED_SPECIAL_CHARS = getFilteredSpecialChars();
-    private static final Set<Character> SUBSTITUTE_CHARS = new HashSet<>();
+    private static final Set<Character> SUBSTITUTE_CHARS = getAllSubstituteChars();
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
@@ -32,77 +29,41 @@ public class BannedWordsFilter extends ListenerAdapter {
             return;
         }
 
-        var msg = event.getMessage().getContentRaw();
-        //we exclude any URLs/links, they do not need to be checked and
-        // would report false positives if they had any sub chars in them (they likely do)
+        String msg = event.getMessage().getContentRaw();
+        //exclude links for potential false positive
         msg = msg.replaceAll("https?:\\/\\/\\S+", "");
-        var msgEmojisConvertedToChars = EmojiHelper.emojiToChar(msg);
-        var msgEmojisConvertedToCharsTrimmed = msgEmojisConvertedToChars.replaceAll(" ", "");
-        //keep this for now commented, the below was just the normal msg without the EmojiHelper
-        //but since EmojiHelper also just sends the msg we would have duplicates so im p sure we can remove this
-        //im keeping this in case it breaks but this will be removed post v1 probably
-//        var msgAsArray = msg.split(" ");
-//        var msgAsArrayTrimmed = Arrays.stream(msgAsArray).filter(word -> !word.isEmpty()).toArray(String[]::new);
-//        var msgAsArrayAsList = Arrays.stream(msgAsArrayTrimmed).distinct().toList();
+        String msgEmojisConvertedToChars = EmojiHelper.emojiToChar(msg);
+        String msgEmojisConvertedToCharsTrimmed = msgEmojisConvertedToChars.replaceAll(" ", "");
 
-//        StringBuilder msgAsArrayAsListString = new StringBuilder();
-//        msgAsArrayAsList.forEach(msgAsArrayAsListString::append);
+        String msgTotal = (msgEmojisConvertedToChars + " " + msgEmojisConvertedToCharsTrimmed);
 
-        var msgTotal = (msgEmojisConvertedToChars + " " + msgEmojisConvertedToCharsTrimmed);
+        for (Character c : FILTERED_SPECIAL_CHARS)
+            msgTotal = msgTotal.replace(c.toString(), "");
 
-        // filter out any char that would be in the way of filter such as quotes ""
-        for (var item : FILTERED_SPECIAL_CHARS) {
-            log.debug("[onMessageReceived] Looping over special chars {}", item.toString());
+        String[] msgTotalArray = Arrays.stream(msgTotal.split(" ")).distinct().toList().toArray(new String[0]);
+        String[] msgTotalArrayTrimmed = Arrays.stream(msgTotalArray).filter(word -> !word.isEmpty()).toArray(String[]::new);
 
-            msgTotal = msgTotal.replace(item.toString(), "");
-        }
-
-        var msgTotalArray = Arrays.stream(msgTotal.split(" ")).distinct().toList().toArray(new String[0]);
-        var msgTotalArrayTrimmed = Arrays.stream(msgTotalArray).filter(word -> !word.isEmpty()).toArray(String[]::new);
-
-        // skip the heavy (slow) substitute method if possible
         if (checkMsgBeforeSubstituting(msgTotalArray, event, msg))
             return;
 
-        //the below two for loops are used to check if there are any substitute chars in current msg
-        // if NOT skip checking for banned words since we did that above
-        // letters: a, b, c,...
-        for (var key : SUBS_PER_CHAR.keySet()) {
+        boolean hasSubInMsg = false;
+        boolean hasDoubleAntiCensorChar = false;
+        int countSubChars = 0;
+        boolean tooManySubCharsInMessage = false;
+        for (String word : msgTotalArray) {
 
-            log.debug("[onMessageReceived] letter: {}", key.toString());
+            char[] wordAsCharArray = word.toCharArray();
 
-            // substitute chars: @, 4, !, ...
-            for (var value : SUBS_PER_CHAR.get(key)) {
-
-                log.debug("[onMessageReceived] substitute char: {}", value.toString());
-                SUBSTITUTE_CHARS.add(value);
-
-            }
-        }
-
-        var hasSubInMsg = false;
-        var hasDoubleAntiCensorChar = false;
-        var countSubChars = 0;
-        var tooManySubCharsInMessage = false;
-        for (var word : msgTotalArray) {
-
-            var charArray = word.toCharArray();
-
-            //same as foreach char of word
-            for (var character : charArray){
-
-                log.debug("[onMessageReceived] character {}", character);
+            for (char character : wordAsCharArray){
 
                 if (SUBSTITUTE_CHARS.contains(character)) {
-                    log.debug("[onMessageReceived] Substitute char detected");
                     hasSubInMsg = true;
                     countSubChars++;
                 }
 
-                if (DOUBLE_ANTI_CENSOR_CHARS.contains(character)) {
-                    log.debug("[onMessageReceived] (potential) Anti double char detected");
+                if (DOUBLE_ANTI_CENSOR_CHARS.contains(character))
                     hasDoubleAntiCensorChar = true;
-                }
+
             }
         }
 
@@ -537,6 +498,10 @@ public class BannedWordsFilter extends ListenerAdapter {
         subsForChars.put('o', List.of('0', '●', '○', '°', '@'));
 
         return subsForChars;
+    }
+
+    private static HashSet<Character> getAllSubstituteChars() {
+        return new HashSet<>(Set.of('@', '4', '^', '3', '€', '!', '¡', '|', '1', '0', '●', '○', '°'));
     }
 
     /// returns double anti censor candidate chars

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -222,7 +222,7 @@ public class BannedWordsFilter extends ListenerAdapter {
         Map<Integer, Set<Character>> indexForSubs = new HashMap<>();
         Set<Character> potentialSubs = new HashSet<>();
         StringBuilder doubleAntiCensorChecker = new StringBuilder();
-        String newWord;
+        StringBuilder newWord = new StringBuilder();
         int indexForSub = 0;
         boolean isSub = false;
         boolean isDoubleAntiCensorChar = false;
@@ -230,7 +230,7 @@ public class BannedWordsFilter extends ListenerAdapter {
         for (String word : inputList) {
 
             char[] chars = word.toCharArray();
-            newWord = "";
+            newWord.setLength(0);
             indexForSubs.clear();
             potentialSubs.clear();
 
@@ -282,7 +282,7 @@ public class BannedWordsFilter extends ListenerAdapter {
                     log.debug("[substitute] Second char (checking combined word): {}", doubleAntiCensorChecker);
 
                     if (doubleAntiCensorChecker.toString().equals("()")) {
-                        newWord += "o";
+                        newWord.append("o");
                         isDoubleAntiCensorChar = true;
                         continue;
                     }
@@ -291,7 +291,7 @@ public class BannedWordsFilter extends ListenerAdapter {
                     log.error("[substitute] ArrayIndexOutOfBoundsException {}", e.getMessage());
                 }
 
-                newWord += chars[i];
+                newWord.append(chars[i]);
                 log.debug("[substitute] Current new word (building it): {}", newWord);
             }
 

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -23,11 +23,7 @@ public class BannedWordsFilter extends ListenerAdapter {
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
         if (LIST_BANNED_WORDS.isEmpty()) return;
-
-        if (ModerationLib.isMod(event.getMember())) {
-            log.debug("[onMessageReceived] This user is mod, banned words filter not applied.");
-            return;
-        }
+        if (ModerationLib.isMod(event.getMember())) return;
 
         String msg = event.getMessage().getContentRaw();
         //exclude links for potential false positive
@@ -67,20 +63,12 @@ public class BannedWordsFilter extends ListenerAdapter {
             }
         }
 
-        //we could check this per word (currently we take the total amount of the message)
-        // and still substitute if words have less than X sub chars
-        // but I believe this is the better approach as it could technically still
-        // overwhelm the heap memory if someone spams e.g. one sub char in many words
         if (countSubChars > BotConfig.getAllowedAmountSubstituteCharactersPerMessage())
             tooManySubCharsInMessage = true;
 
         log.debug("[onMessageReceived] msg: {}", msg);
         log.debug("[onMessageReceived] msgEmojisConvertedToChars: {}", msgEmojisConvertedToChars);
         log.debug("[onMessageReceived] msgEmojisConvertedToCharsTrimmed: {}", msgEmojisConvertedToCharsTrimmed);
-//        log.debug("[onMessageReceived] msgAsArray: {}", (Object) msgAsArray);
-//        log.debug("[onMessageReceived] msgAsArrayTrimmed: {}", (Object) msgAsArrayTrimmed);
-//        log.debug("[onMessageReceived] msgAsArrayAsList: {}", msgAsArrayAsList);
-//        log.debug("[onMessageReceived] msgAsArrayAsListString: {}", msgAsArrayAsListString);
         log.debug("[onMessageReceived] msgTotal: {}", msgTotal);
         log.debug("[onMessageReceived] msgTotalArray: {}", (Object) msgTotalArray);
         log.debug("[onMessageReceived] msgTotalArrayTrimmed: {}", (Object) msgTotalArrayTrimmed);
@@ -91,19 +79,17 @@ public class BannedWordsFilter extends ListenerAdapter {
 
             if (tooManySubCharsInMessage) {
 
-                var user = event.getAuthor().getAsMention();
-                var msgRaw = event.getMessage().getContentRaw();
-
+                String userMention = event.getAuthor().getAsMention();
                 event.getJDA().getChannelById(TextChannel.class, BotConfig.LOG_CHANNEL_ID)
-                        .sendMessage("**[POTENTIAL BANNED WORD]** " + user + " <M: " + msgRaw + ">").queue();
+                        .sendMessage("**[POTENTIAL BANNED WORD]** " + userMention + " <M: " + msg + ">").queue();
                 return;
             }
 
             return;
         }
 
-        var substitutedMsg = substitute(msgTotalArrayTrimmed, event);
-        var combinedWordsList = getCombinedWords(substitutedMsg);
+        List<String> substitutedMsg = substitute(msgTotalArrayTrimmed, event);
+        List<String> combinedWordsList = getCombinedWords(substitutedMsg);
 
         log.debug("[onMessageReceived] substitutedMsg: {}", substitutedMsg);
         log.debug("[onMessageReceived] combinedWordsList: {}", combinedWordsList);
@@ -133,33 +119,29 @@ public class BannedWordsFilter extends ListenerAdapter {
         }
     }
 
-    /// returns true if there is a banned word spotted in msg without substituting
-    /// this results in significantly faster deleting of the message
+    /// check b4 substituting = fast!
     private boolean checkMsgBeforeSubstituting(String[] msgTotal, MessageReceivedEvent event, String originalMsgRaw) {
 
-        var msgTotalList = Arrays.stream(msgTotal).toList();
-        var combinedWords = getCombinedWords(msgTotalList);
+        List<String> msgTotalList = Arrays.stream(msgTotal).toList();
+        List<String> combinedWords = getCombinedWords(msgTotalList);
 
         log.debug("[checkMsgBeforeSubstituting] msgTotal {}", (Object) msgTotal);
         log.debug("[checkMsgBeforeSubstituting] combinedWords {}", combinedWords);
         log.debug("[checkMsgBeforeSubstituting] msgTotalList {}", msgTotalList);
 
+        if (hasWhitelistedCombinedWords(combinedWords))
+            return hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(combinedWords, event, originalMsgRaw);
+
         // this is copied from above (inside onMessageReceived method), for more info read above
-        for (var word : msgTotalList){
+        for (String word : msgTotalList) {
 
-            if (hasWhitelistedCombinedWords(combinedWords)) {
-                return loopOverMsgExcludeWhitelistBoolean(combinedWords, msgTotalList, event, originalMsgRaw);
-            }
-
-            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equals(word))) {
-                return loopOverMsgExcludeWhitelistBoolean(word, msgTotalList, event, originalMsgRaw);
-            }
+            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equals(word)))
+                return hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(word, msgTotalList, event, originalMsgRaw);
 
             if (LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))) {
                 deleteMsg(event, originalMsgRaw, word);
                 return true;
             }
-
         }
 
         return false;
@@ -175,20 +157,30 @@ public class BannedWordsFilter extends ListenerAdapter {
                 .queue();
     }
 
-    /// This variant is made for checkMsgBeforeSubstituting method
-    /// Loops over msgTotal, for each word looks for any non-whitelisted combined word (2 words)
-    /// AND if it is a banned word, if yes it calls the delete method AND returns true (so that substitute method is skipped)
-    private boolean loopOverMsgExcludeWhitelistBoolean(List<String> combinedWordsList, List<String> msgTotalList, MessageReceivedEvent event, String msg){
+    /// combined word variant
+    private boolean hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(List<String> combinedWordsList, MessageReceivedEvent event, String msg) {
 
-        var whitelistedWords = getWhitelistedWords(combinedWordsList);
+        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] Checking for banned words before substituting combined words variant");
 
-        log.debug("[loopOverMsgExcludeWhitelistBoolean] (combined whitelist word) msgTotalList: {}", msgTotalList);
-        log.debug("[loopOverMsgExcludeWhitelistBoolean] (combined whitelist word) whiteListedWords: {}", whitelistedWords);
+        String newMsg = "";
+        List<String> newMsgAsList;
 
-        for (String word : msgTotalList){
-            if (!whitelistedWords.contains(word) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))){
-                log.debug("[loopOverMsgExcludeWhitelistBoolean] NON-WHITELIST BANNED WORD: {}", word);
+        for (String combinedWord : combinedWordsList) {
+            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(combinedWord))) {
+                newMsg = msg.replaceAll(combinedWord, "");
+                log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] whitelisted combined word found: {}", combinedWord);
+            }
+        }
 
+        newMsgAsList = Arrays.asList(newMsg.trim().split(" "));
+
+        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] newMsg: {}", newMsg);
+        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] newMsgAsList: {}", newMsgAsList);
+
+        for (String word : newMsgAsList){
+            //should we check whitelist word case-sensitive? idk prob not... -_o_-
+            if (!WHITELISTED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word)) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))){
+                log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] NON-WHITELIST BANNED WORD: {}", word);
                 deleteMsg(event, msg, word);
                 return true;
             }
@@ -197,17 +189,15 @@ public class BannedWordsFilter extends ListenerAdapter {
         return false;
     }
 
-    /// This variant is made for checkMsgBeforeSubstituting method
-    /// Loops over msgTotal, for each word looks for any non-whitelisted word
-    /// AND if it is a banned word, if yes it calls the delete method AND returns true (so that substitute method is skipped)
-    private boolean loopOverMsgExcludeWhitelistBoolean(String whitelistedWord, List<String> msgTotalList, MessageReceivedEvent event, String msg){
+    /// singular word variant
+    private boolean hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(String whitelistedWord, List<String> msgTotalList, MessageReceivedEvent event, String msg){
 
-        log.debug("[loopOverMsgExcludeWhitelistBoolean] (single whitelist word) msgTotalList: {}", msgTotalList);
-        log.debug("[loopOverMsgExcludeWhitelistBoolean] (single whitelist word) whitelistedWord: {}", whitelistedWord);
+        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] (single whitelist word) msgTotalList: {}", msgTotalList);
+        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] (single whitelist word) whitelistedWord: {}", whitelistedWord);
 
         for (String word : msgTotalList){
             if (!whitelistedWord.equals(word) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))){
-                log.debug("[loopOverMsgExcludeWhitelistBoolean] NON-WHITELIST BANNED WORD: {}", word);
+                log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] NON-WHITELIST BANNED WORD: {}", word);
 
                 deleteMsg(event, msg, word);
                 return true;
@@ -489,7 +479,6 @@ public class BannedWordsFilter extends ListenerAdapter {
         }
     }
 
-    /// returns current subs supported per character
     private static Map<Character, List<Character>> getSubsForChars() {
         Map<Character, List<Character>> subsForChars = new HashMap<>();
         subsForChars.put('a', List.of('@', '4', '^'));
@@ -504,7 +493,6 @@ public class BannedWordsFilter extends ListenerAdapter {
         return new HashSet<>(Set.of('@', '4', '^', '3', '€', '!', '¡', '|', '1', '0', '●', '○', '°'));
     }
 
-    /// returns double anti censor candidate chars
     private static Set<Character> getPotentialDoubleAntiCensor() {
         Set<Character> doubleAntiCensorChars = new HashSet<>();
         doubleAntiCensorChars.add('(');
@@ -513,7 +501,6 @@ public class BannedWordsFilter extends ListenerAdapter {
         return doubleAntiCensorChars;
     }
 
-    /// returns special chars that are removed from original msg before filter
     private static Set<Character> getFilteredSpecialChars() {
         Set<Character> filteredSpecialChars = new HashSet<>();
         filteredSpecialChars.add('\"');

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -47,7 +47,6 @@ public class BannedWordsFilter extends ListenerAdapter {
         log.debug("[onMessageReceived] msgTotal: {}", msgTotal);
         log.debug("[onMessageReceived] msgTotalArray: {}", (Object) msgTotalArray);
         log.debug("[onMessageReceived] combinedWords: {}", combinedWords);
-        log.debug("[onMessageReceived] LIST_BANNED_WORDS: {}", LIST_BANNED_WORDS);
 
         if (hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(combinedWords, event, msgTotal)) return;
 

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -1,7 +1,6 @@
 package va.rembot.moderation.word_filter;
 
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import va.rembot.BotConfig;
@@ -21,36 +20,45 @@ public class BannedWordsFilter extends ListenerAdapter {
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
-        if (event.getAuthor().isBot()) return;
         if (LIST_BANNED_WORDS.isEmpty()) return;
+        if (event.getAuthor().isBot()) return;
         if (ModerationLib.isMod(event.getMember())) return;
 
         String msg = event.getMessage().getContentRaw();
-        //exclude links for potential false positive
-        msg = msg.replaceAll("https?:\\/\\/\\S+", "");
+        msg = msg.replaceAll("https?://\\S+", "");
         String msgEmojisConvertedToChars = EmojiHelper.emojiToChar(msg);
-        String msgEmojisConvertedToCharsTrimmed = msgEmojisConvertedToChars.replaceAll(" ", "");
+        String msgEmojisConvertedToCharsTrimmed = msgEmojisConvertedToChars.replace(" ", "");
 
         String msgTotal = (msgEmojisConvertedToChars + " " + msgEmojisConvertedToCharsTrimmed);
 
         for (Character c : FILTERED_SPECIAL_CHARS)
             msgTotal = msgTotal.replace(c.toString(), "");
 
-        String[] msgTotalArray = Arrays.stream(msgTotal.split(" ")).distinct().toList().toArray(new String[0]);
-        String[] msgTotalArrayTrimmed = Arrays.stream(msgTotalArray).filter(word -> !word.isEmpty()).toArray(String[]::new);
+        String[] msgTotalArray = Arrays.stream(msgTotal.split(" "))
+                .distinct()
+                .filter(word -> !word.isEmpty())
+                .toList().toArray(new String[0]);
 
-        if (checkMsgBeforeSubstituting(msgTotalArray, event, msg))
-            return;
+        List<String> combinedWords = getCombinedWords(Arrays.stream(msgTotalArray).toList());
 
-        boolean hasSubInMsg = false;
-        boolean hasDoubleAntiCensorChar = false;
+        log.debug("[onMessageReceived] msg: {}", msg);
+        log.debug("[onMessageReceived] msgEmojisConvertedToChars: {}", msgEmojisConvertedToChars);
+        log.debug("[onMessageReceived] msgEmojisConvertedToCharsTrimmed: {}", msgEmojisConvertedToCharsTrimmed);
+        log.debug("[onMessageReceived] msgTotal: {}", msgTotal);
+        log.debug("[onMessageReceived] msgTotalArray: {}", (Object) msgTotalArray);
+        log.debug("[onMessageReceived] combinedWords: {}", combinedWords);
+        log.debug("[onMessageReceived] LIST_BANNED_WORDS: {}", LIST_BANNED_WORDS);
+
+        if (hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(combinedWords, event, msgTotal)) return;
+
+        boolean hasSubInMsg, hasDoubleAntiCensorChar, tooManySubCharsInMessage;
+        hasSubInMsg = hasDoubleAntiCensorChar = tooManySubCharsInMessage = false;
         int countSubChars = 0;
-        boolean tooManySubCharsInMessage = false;
         for (String word : msgTotalArray) {
 
             char[] wordAsCharArray = word.toCharArray();
 
-            for (char character : wordAsCharArray){
+            for (char character : wordAsCharArray) {
 
                 if (SUBSTITUTE_CHARS.contains(character)) {
                     hasSubInMsg = true;
@@ -59,92 +67,33 @@ public class BannedWordsFilter extends ListenerAdapter {
 
                 if (DOUBLE_ANTI_CENSOR_CHARS.contains(character))
                     hasDoubleAntiCensorChar = true;
-
             }
         }
 
         if (countSubChars > BotConfig.getAllowedAmountSubstituteCharactersPerMessage())
             tooManySubCharsInMessage = true;
 
-        log.debug("[onMessageReceived] msg: {}", msg);
-        log.debug("[onMessageReceived] msgEmojisConvertedToChars: {}", msgEmojisConvertedToChars);
-        log.debug("[onMessageReceived] msgEmojisConvertedToCharsTrimmed: {}", msgEmojisConvertedToCharsTrimmed);
-        log.debug("[onMessageReceived] msgTotal: {}", msgTotal);
-        log.debug("[onMessageReceived] msgTotalArray: {}", (Object) msgTotalArray);
-        log.debug("[onMessageReceived] msgTotalArrayTrimmed: {}", (Object) msgTotalArrayTrimmed);
-        log.debug("[onMessageReceived] LIST_BANNED_WORDS: {}", LIST_BANNED_WORDS);
         log.debug("[onMessageReceived] tooManySubCharsInMessage: {}", tooManySubCharsInMessage);
 
-        if (!hasSubInMsg && !hasDoubleAntiCensorChar || tooManySubCharsInMessage) {
-
-            if (tooManySubCharsInMessage) {
-
-                String userMention = event.getAuthor().getAsMention();
-                event.getJDA().getChannelById(TextChannel.class, BotConfig.LOG_CHANNEL_ID)
-                        .sendMessage("**[POTENTIAL BANNED WORD]** " + userMention + " <M: " + msg + ">").queue();
-                return;
-            }
-
+        if (!hasSubInMsg && !hasDoubleAntiCensorChar || tooManySubCharsInMessage)
             return;
-        }
 
-        List<String> substitutedMsg = substitute(msgTotalArrayTrimmed, event);
+            //this is super spammy with a lot of false positives, keeping it for future but will likely never be used
+//            if (tooManySubCharsInMessage) {
+//
+//                String userMention = event.getAuthor().getAsMention();
+//                event.getJDA().getChannelById(TextChannel.class, BotConfig.LOG_CHANNEL_ID)
+//                        .sendMessage("**[POTENTIAL BANNED WORD]** " + userMention + " <M: " + msg + ">").queue();
+//                return;
+//            }
+
+        List<String> substitutedMsg = substitute(msgTotalArray);
         List<String> combinedWordsList = getCombinedWords(substitutedMsg);
 
         log.debug("[onMessageReceived] substitutedMsg: {}", substitutedMsg);
         log.debug("[onMessageReceived] combinedWordsList: {}", combinedWordsList);
 
-        for (String word : substitutedMsg) {
-
-            // check if msg has any combined words that are whitelisted
-            // if so, exclude the whitelisted words from the original msg
-            // and do another loop over this new list checking
-            // if there are any banned words present
-            if (hasWhitelistedCombinedWords(combinedWordsList)) {
-                loopOverMsgExcludeWhitelist(combinedWordsList, substitutedMsg, event, msg);
-                break;
-            }
-
-            // check message for a single whitelisted word afterward loop over list
-            // excluding the whitelisted word and check again for banned words
-            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equals(word))) {
-                loopOverMsgExcludeWhitelist(word, substitutedMsg, event, msg);
-                break;
-            }
-
-            if (LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))) {
-                deleteMsg(event, msg, word);
-                break;
-            }
-        }
-    }
-
-    /// check b4 substituting = fast!
-    private boolean checkMsgBeforeSubstituting(String[] msgTotal, MessageReceivedEvent event, String originalMsgRaw) {
-
-        List<String> msgTotalList = Arrays.stream(msgTotal).toList();
-        List<String> combinedWords = getCombinedWords(msgTotalList);
-
-        log.debug("[checkMsgBeforeSubstituting] msgTotal {}", (Object) msgTotal);
-        log.debug("[checkMsgBeforeSubstituting] combinedWords {}", combinedWords);
-        log.debug("[checkMsgBeforeSubstituting] msgTotalList {}", msgTotalList);
-
-        if (hasWhitelistedCombinedWords(combinedWords))
-            return hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(combinedWords, event, originalMsgRaw);
-
-        // this is copied from above (inside onMessageReceived method), for more info read above
-        for (String word : msgTotalList) {
-
-            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equals(word)))
-                return hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(word, msgTotalList, event, originalMsgRaw);
-
-            if (LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))) {
-                deleteMsg(event, originalMsgRaw, word);
-                return true;
-            }
-        }
-
-        return false;
+        checkMessageForBannedWordExcludingWhitelisted(combinedWordsList, substitutedMsg, event, msg);
     }
 
     private void deleteMsg(MessageReceivedEvent event, String msg, String bannedWord){
@@ -157,18 +106,19 @@ public class BannedWordsFilter extends ListenerAdapter {
                 .queue();
     }
 
-    /// combined word variant
     private boolean hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(List<String> combinedWordsList, MessageReceivedEvent event, String msg) {
 
         log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] Checking for banned words before substituting combined words variant");
 
-        String newMsg = "";
+        String newMsg = msg;
         List<String> newMsgAsList;
 
-        for (String combinedWord : combinedWordsList) {
-            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(combinedWord))) {
-                newMsg = msg.replaceAll(combinedWord, "");
-                log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] whitelisted combined word found: {}", combinedWord);
+        if (hasWhitelistedCombinedWords(combinedWordsList)) {
+            for (String combinedWord : combinedWordsList) {
+                if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(combinedWord))) {
+                    newMsg = newMsg.replaceAll(combinedWord, "");
+                    log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] whitelisted combined word found: {}", combinedWord);
+                }
             }
         }
 
@@ -177,9 +127,9 @@ public class BannedWordsFilter extends ListenerAdapter {
         log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] newMsg: {}", newMsg);
         log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] newMsgAsList: {}", newMsgAsList);
 
-        for (String word : newMsgAsList){
+        for (String word : newMsgAsList) {
             //should we check whitelist word case-sensitive? idk prob not... -_o_-
-            if (!WHITELISTED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word)) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))){
+            if (WHITELISTED_WORDS.stream().noneMatch(s -> s.equalsIgnoreCase(word)) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))) {
                 log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] NON-WHITELIST BANNED WORD: {}", word);
                 deleteMsg(event, msg, word);
                 return true;
@@ -189,90 +139,49 @@ public class BannedWordsFilter extends ListenerAdapter {
         return false;
     }
 
-    /// singular word variant
-    private boolean hasBannedWordExcludingWhitelistedWordsBeforeSubstituting(String whitelistedWord, List<String> msgTotalList, MessageReceivedEvent event, String msg){
+    private void checkMessageForBannedWordExcludingWhitelisted(List<String> combinedWordsList, List<String> substituteMsg, MessageReceivedEvent event, String msg) {
 
-        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] (single whitelist word) msgTotalList: {}", msgTotalList);
-        log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] (single whitelist word) whitelistedWord: {}", whitelistedWord);
+        StringBuilder sb = new StringBuilder();
+        String newMessage;
+        List<String> newMessageAsList;
 
-        for (String word : msgTotalList){
-            if (!whitelistedWord.equals(word) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))){
-                log.debug("[hasBannedWordExcludingWhitelistedWordsBeforeSubstituting] NON-WHITELIST BANNED WORD: {}", word);
+        for (String word : substituteMsg)
+            sb.append(word).append(" ");
 
-                deleteMsg(event, msg, word);
-                return true;
-            }
-        }
+        newMessage = sb.toString().trim();
 
-        return false;
-    }
+        log.debug("[checkMessageForBannedWordExcludingWhitelisted] substituteMsg: {}", substituteMsg);
+        log.debug("[checkMessageForBannedWordExcludingWhitelisted] newMessage: {}", newMessage);
 
-    /// Loops over substituted message, for each word looks for any non-whitelisted combined word (2 words)
-    /// AND if it is a banned word, if yes it calls the delete method
-    private void loopOverMsgExcludeWhitelist(List<String> combinedWordsList, List<String> substituteMsg, MessageReceivedEvent event, String msg){
-
-        var whitelistedWords = getWhitelistedWords(combinedWordsList);
-
-        log.debug("[loopOverMsgExcludeWhitelist] (combined whitelist word) substituteMsg: {}", substituteMsg);
-        log.debug("[loopOverMsgExcludeWhitelist] (combined whitelist word) whiteListedWords: {}", whitelistedWords);
-
-        for (String word : substituteMsg){
-            if (!whitelistedWords.contains(word) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))){
-                log.debug("[loopOverMsgExcludeWhitelist] NON-WHITELIST BANNED WORD: {}", word);
-
-                deleteMsg(event, msg, word);
-                break;
-            }
-        }
-    }
-
-    /// Loops over substituted message, for each word looks for any non-whitelisted word
-    /// AND if it is a banned word, if yes it calls the delete method
-    private void loopOverMsgExcludeWhitelist(String whitelistedWord, List<String> substituteMsg, MessageReceivedEvent event, String msg){
-
-        log.debug("[loopOverMsgExcludeWhitelist] (single whitelist word) substituteMsg: {}", substituteMsg);
-        log.debug("[loopOverMsgExcludeWhitelist] (single whitelist word) whitelistedWord: {}", whitelistedWord);
-
-        for (String word : substituteMsg){
-            if (!whitelistedWord.equals(word) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))){
-                log.debug("[loopOverMsgExcludeWhitelist] NON-WHITELIST BANNED WORD: {}", word);
-
-                deleteMsg(event, msg, word);
-                break;
-            }
-        }
-    }
-
-    /// returns true if input list has a whitelisted combined word
-    private boolean hasWhitelistedCombinedWords(List<String> combinedWordsList){
-
-        for (String word : combinedWordsList){
-            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equals(word))){
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// returns a list of strings of whitelisted combined words split up (e.g. ["Good Word"] becomes ["Good", "Word"]
-    private List<String> getWhitelistedWords(List<String> combinedWordsList){
-
-        List<String> whitelistedWordsList = new ArrayList<>();
-
-        for (String combinedWord : combinedWordsList){
-            if (WHITELISTED_WORDS.contains(combinedWord)){
-                log.debug("[getWhitelistedWords] combined word: {}", Arrays.toString(combinedWord.split(" ")));
-
-                for (String word : combinedWord.split(" ")){
-                    log.debug("[getWhitelistedWords] Whitelisted decombined word: {}", word);
-                    whitelistedWordsList.add(word);
+        if (hasWhitelistedCombinedWords(combinedWordsList)) {
+            for (String combinedWord : combinedWordsList) {
+                if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(combinedWord))) {
+                    newMessage = newMessage.replaceAll(combinedWord, "");
+                    log.debug("[checkMessageForBannedWordExcludingWhitelisted] whitelisted combined word found: {}", combinedWord);
                 }
             }
         }
 
-        log.debug("[getWhitelistedWords] returning whitelistedWordsList: {}", whitelistedWordsList);
-        return whitelistedWordsList;
+        newMessageAsList = Arrays.asList(newMessage.trim().split(" "));
+
+        log.debug("[checkMessageForBannedWordExcludingWhitelisted] newMessageAsList: {}", newMessageAsList);
+
+        for (String word : newMessageAsList) {
+            if (WHITELISTED_WORDS.stream().noneMatch(s -> s.equalsIgnoreCase(word)) && LIST_BANNED_WORDS.stream().anyMatch(s -> s.equalsIgnoreCase(word))) {
+                log.debug("[checkMessageForBannedWordExcludingWhitelisted] NON-WHITELIST BANNED WORD: {}", word);
+                deleteMsg(event, msg, word);
+                break;
+            }
+        }
+    }
+
+    private boolean hasWhitelistedCombinedWords(List<String> combinedWordsList) {
+
+        for (String word : combinedWordsList)
+            if (WHITELISTED_WORDS.stream().anyMatch(s -> s.equals(word)))
+                return true;
+
+        return false;
     }
 
     private List<String> getCombinedWords(List<String> substitutedMsg) {
@@ -282,11 +191,10 @@ public class BannedWordsFilter extends ListenerAdapter {
         int comboWordIndexStart = 0;
         int comboWordIndexNext = 1;
 
-        for (int i = 0; i < substitutedMsg.size(); i++){
+        for (int i = 0; i < substitutedMsg.size(); i++) {
 
             // combined word cant be one word
-            if (substitutedMsg.size() == 1)
-                break;
+            if (substitutedMsg.size() == 1) break;
 
             log.debug("[getCombinedWords] Combo word ONE: {}", substitutedMsg.get(comboWordIndexStart));
             log.debug("[getCombinedWords] Combo word TWO: {}", substitutedMsg.get(comboWordIndexNext));
@@ -300,43 +208,29 @@ public class BannedWordsFilter extends ListenerAdapter {
             comboWordIndexStart += 1;
             comboWordIndexNext += 1;
 
-            // prevent out of bounds error when going through list:
-            if (comboWordIndexStart >= substitutedMsg.size() || comboWordIndexNext + 1 >= substitutedMsg.size())
-                break;
+            if (comboWordIndexStart >= substitutedMsg.size() || comboWordIndexNext + 1 >= substitutedMsg.size()) break;
         }
 
         log.debug("[getCombinedWords] The list being returned: {}", combinedWordsList);
         return combinedWordsList;
     }
 
-    /// 1. take an array of strings
-    /// 2. loop over each word
-    /// 3. loop over each char of the words and rebuild each word
-    /// 4. if there is a potential substitute character put it in a Map
-    /// with Integer and List Character (substitutes that are possible per index of word)
-    /// 5. Send each word to replaceSubWithChar() with the Map and make all variants
-    /// of the word with their normal characters
-    private List<String> substitute(String[] inputList, MessageReceivedEvent event){
+    private List<String> substitute(String[] inputList) {
 
-        int amountOfSubWords = 0;
-        String newWord;
         List<String> newList = new ArrayList<>();
-
         Map<Character, List<Character>> subsForChars = SUBS_PER_CHAR;
-
-        // per index can be multiple subs
         Map<Integer, Set<Character>> indexForSubs = new HashMap<>();
-        // prevent duplicates
         Set<Character> potentialSubs = new HashSet<>();
+        StringBuilder doubleAntiCensorChecker = new StringBuilder();
+        String newWord;
         int indexForSub = 0;
         boolean isSub = false;
-        StringBuilder doubleAntiCensorChecker = new StringBuilder();
-        boolean skip = false;
+        boolean isDoubleAntiCensorChar = false;
 
         for (String word : inputList) {
 
             char[] chars = word.toCharArray();
-            newWord = ""; //not really new word unless double anti censor keep var name unless better found
+            newWord = "";
             indexForSubs.clear();
             potentialSubs.clear();
 
@@ -345,29 +239,25 @@ public class BannedWordsFilter extends ListenerAdapter {
 
             for (int i = 0; i < word.length(); i++) {
 
-                // need this for checking if double characters are a specific letter
-                // such as () becomes the letter o
-                if (skip){
-                    skip = false;
+                if (isDoubleAntiCensorChar) {
+                    isDoubleAntiCensorChar = false;
                     continue;
                 }
 
                 doubleAntiCensorChecker.setLength(0);
 
                 log.debug("[substitute] Every character {}", chars[i]);
-
-                // if char is a suspected substitute:
                 log.debug("[substitute] KEYS of subsForChars: {}", subsForChars.keySet());
 
                 // example a, b, c, ... (letters)
-                for (var key : subsForChars.keySet()){
+                for (var key : subsForChars.keySet()) {
                     log.debug("[substitute] Each key (subsForChars): {}", key);
 
                     // example @, 4, ... (substitute chars/replacements)
-                    for (var value : subsForChars.get(key)){
+                    for (var value : subsForChars.get(key)) {
                         log.debug("[substitute] Each value (subsForChars): {} for key: {}", value, key);
 
-                        if (value.equals(chars[i])){
+                        if (value.equals(chars[i])) {
                             log.debug("[substitute] Substitute char found: {} in word: {}", value, word);
                             potentialSubs.add(key);
                             indexForSub = i;
@@ -376,17 +266,14 @@ public class BannedWordsFilter extends ListenerAdapter {
                     }
                 }
 
-                if (isSub) {
+                if (isSub)
                     indexForSubs.put(indexForSub, potentialSubs);
-                }
+
                 log.debug("[substitute] indexForSubs BUILDING IT: {}", indexForSubs);
                 log.debug("[substitute] potentialSubs: {}", potentialSubs);
                 log.debug("[substitute] Current index: {}", i);
 
-
-                // this is for converting 2 chars into a letter
                 try {
-
                     doubleAntiCensorChecker.append(chars[i]);
                     log.debug("[substitute] First char (checking combined word): {}", doubleAntiCensorChecker);
 
@@ -394,37 +281,18 @@ public class BannedWordsFilter extends ListenerAdapter {
                         doubleAntiCensorChecker.append(chars[i + 1]);
                     log.debug("[substitute] Second char (checking combined word): {}", doubleAntiCensorChecker);
 
-                    // add more if statements for 2 characters that can be converted to a letter
-                    if (doubleAntiCensorChecker.toString().equals("()")){
+                    if (doubleAntiCensorChecker.toString().equals("()")) {
                         newWord += "o";
-                        skip = true; // skip another iteration because we merged 2 characters into 1
+                        isDoubleAntiCensorChar = true;
                         continue;
                     }
+
                 } catch (ArrayIndexOutOfBoundsException e) {
                     log.error("[substitute] ArrayIndexOutOfBoundsException {}", e.getMessage());
                 }
 
                 newWord += chars[i];
                 log.debug("[substitute] Current new word (building it): {}", newWord);
-            }
-
-            if (isSub)
-                amountOfSubWords++;
-
-            // we can change amountOfSubWords to any number but higher = less performant
-            // we do + 1 because we also include a concatenated message of the original
-            // for example original message "badword badword2" would become "badword" "badword2" "badwordbadword2"
-            if (isSub && amountOfSubWords > BotConfig.getSubstituteBannedWordCheckAmountInt() + 1) {
-                log.debug("[substitute] At least one word found with substitute char, only checking this word.");
-
-                //we should put this in lib/extracted method see issue #35 and #40
-                var user = event.getAuthor().getAsMention();
-                var msgRaw = event.getMessage().getContentRaw();
-
-                event.getJDA().getChannelById(TextChannel.class, BotConfig.LOG_CHANNEL_ID)
-                        .sendMessage("**[POTENTIAL BANNED WORD]** " + user + " <M: " + msgRaw + ">").queue();
-
-                break;
             }
 
             StringBuilder stringBuilder = new StringBuilder(newWord);
@@ -440,33 +308,21 @@ public class BannedWordsFilter extends ListenerAdapter {
         return newList;
     }
 
-    /// THIS HAPPENS WORD PER WORD FROM SUBSTITUTE()
-    /// This method is essential part of substitute and does the main work it uses backtracking to make each variant
-    /// 1. check if index is string's length = we checked every character
-    /// 2. Check if current index (starts with 0) has any substitute characters by using the possibleSubs map
-    /// 2.1. If there is a substitute character use the stored set and loop over each one and replace them
-    ///   (this is done recursively by calling the same method again added a higher index of 1)
-    /// 2.2. If there is no substitute char at this index just go to next index
-    /// 3. When done back at the first if put in newList
-    /// /!\ if a message is huge AND it contains potential substitute chars this will throw a java.lang.OutOfMemoryError
-    /// I m not sure how to handle this atm, basically the message will just be sent to disc and not handled properly
-    /// this is also pretty slow for big messages but it works so I'll keep it,
-    /// need to find some way to make this more performant in the future
-    public static void replaceSubWithChar(StringBuilder stringBuilder, int index, Map<Integer, Set<Character>> possibleSubs, List<String> newList){
+    public static void replaceSubWithChar(StringBuilder stringBuilder, int index, Map<Integer, Set<Character>> possibleSubs, List<String> newList) {
 
-        if (index == stringBuilder.length()){
+        if (index == stringBuilder.length()) {
             newList.add(String.valueOf(stringBuilder));
             log.debug("[replaceSubWithChar] newList replacing subs with normal chars: {}", newList);
             log.debug("[replaceSubWithChar] stringBuilder value at end: {}", stringBuilder);
             return;
         }
 
-        if (possibleSubs.containsKey(index)){
+        if (possibleSubs.containsKey(index)) {
 
             char originalChar = stringBuilder.charAt(index);
             log.debug("[replaceSubWithChar] originalChar: {}", originalChar);
 
-            for (Character sub : possibleSubs.get(index)){
+            for (Character sub : possibleSubs.get(index)) {
                 stringBuilder.setCharAt(index, sub);
                 log.debug("[replaceSubWithChar] sub: {}", sub);
 

--- a/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
+++ b/src/main/java/va/rembot/moderation/word_filter/BannedWordsFilter.java
@@ -234,8 +234,8 @@ public class BannedWordsFilter extends ListenerAdapter {
             indexForSubs.clear();
             potentialSubs.clear();
 
-            log.debug("[substitute method] characters: {}", Arrays.toString(chars));
-            log.debug("[substitute method] word: {}", word);
+            log.debug("[substitute] characters: {}", Arrays.toString(chars));
+            log.debug("[substitute] word: {}", word);
 
             for (int i = 0; i < word.length(); i++) {
 
@@ -250,11 +250,11 @@ public class BannedWordsFilter extends ListenerAdapter {
                 log.debug("[substitute] KEYS of subsForChars: {}", subsForChars.keySet());
 
                 // example a, b, c, ... (letters)
-                for (var key : subsForChars.keySet()) {
+                for (Character key : subsForChars.keySet()) {
                     log.debug("[substitute] Each key (subsForChars): {}", key);
 
                     // example @, 4, ... (substitute chars/replacements)
-                    for (var value : subsForChars.get(key)) {
+                    for (Character value : subsForChars.get(key)) {
                         log.debug("[substitute] Each value (subsForChars): {} for key: {}", value, key);
 
                         if (value.equals(chars[i])) {

--- a/src/main/java/va/rembot/moderation/word_filter/EmojiHelper.java
+++ b/src/main/java/va/rembot/moderation/word_filter/EmojiHelper.java
@@ -23,6 +23,20 @@ public class EmojiHelper {
         return msgExcludingEmojis;
     }
 
+    public static boolean hasLetterEmojiInMessage(String message) {
+
+        log.debug("[hasLetterEmojiInMessage] message: {}", message);
+
+        for (String emoji : emojiSubsMap().keySet()) {
+
+            log.debug("[hasLetterEmojiInMessage] emoji: {}", emoji);
+
+            if (message.contains(emoji))
+                return true;
+        }
+        return false;
+    }
+
     private static Map<String, Character> emojiSubsMap() {
 
         HashMap<String, Character> emojiForChar = new HashMap<>();

--- a/src/main/java/va/rembot/moderation/word_filter/EmojiHelper.java
+++ b/src/main/java/va/rembot/moderation/word_filter/EmojiHelper.java
@@ -8,7 +8,6 @@ import java.util.Map;
 @Slf4j
 public class EmojiHelper {
 
-    /// Converts all emojis (that are registered in emojiSubsMap()) to their corresponding character.
     public static String emojiToChar(String msg) {
 
         String msgExcludingEmojis = msg;
@@ -26,9 +25,6 @@ public class EmojiHelper {
 
     private static Map<String, Character> emojiSubsMap() {
 
-        // the keys are the UTF-16 Encodings (hexadecimal format) for each emoji
-        // the values represent the normal char they replace
-        // (just paste an emoji between "" and it should put the Unicode)
         HashMap<String, Character> emojiForChar = new HashMap<>();
         emojiForChar.put("\uD83C\uDDE6", 'a');
         emojiForChar.put("\uD83C\uDDE7", 'b');

--- a/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
+++ b/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
@@ -13,7 +13,7 @@ import va.rembot.BotConfig;
 import va.rembot.database.dao.MessageDao;
 import va.rembot.database.dao.StarMessageDao;
 import va.rembot.database.dao.UserDao;
-import va.rembot.database.models.Message;
+import va.rembot.database.models.DiscordMessage;
 import va.rembot.database.models.StarMessage;
 import va.rembot.database.models.DiscordUser;
 import va.rembot.exceptions.MessageNotFoundException;
@@ -282,7 +282,7 @@ public class HighlightedMessage extends ListenerAdapter {
         }
 
         userDao.create(new DiscordUser(discordId));
-        msgDao.create(new Message(discordMsgId, discordId, new Timestamp(msgTimeCreated), msgContent, attachmentLinks));
+        msgDao.create(new DiscordMessage(discordMsgId, discordId, new Timestamp(msgTimeCreated), msgContent, attachmentLinks));
     }
 
     private static EmbedBuilder getBaseEmbedMessage(User user, String stars, String messageContent) {

--- a/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
+++ b/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
@@ -24,13 +24,14 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Slf4j
 public class HighlightedMessage extends ListenerAdapter {
 
-    private static String starEmojiUnicode = "U+2B50";
+    private static final String STAR_EMOJI_UNICODE = "U+2B50";
 
     @Override
     public void onMessageReactionAdd(MessageReactionAddEvent event) {
@@ -40,13 +41,13 @@ public class HighlightedMessage extends ListenerAdapter {
                 .asUnicode()
                 .getAsCodepoints();
 
-        if (emojiAsUnicode.equalsIgnoreCase(starEmojiUnicode)) {
+        if (emojiAsUnicode.equalsIgnoreCase(STAR_EMOJI_UNICODE)) {
 
             long msgId = event.getMessageIdLong();
-            var starMsgDao = new StarMessageDao();
-            var msgDao = new MessageDao();
+            StarMessageDao starMessageDao = new StarMessageDao();
+            MessageDao messageDao = new MessageDao();
 
-            var msgObject = msgDao.get(msgId);
+            Optional<DiscordMessage> msgObject = messageDao.get(msgId);
 
             if (msgObject.isEmpty()) {
                 log.error("[onMessageReactionAdd] Couldn't highlight message. Message is not stored in database. This could be because the bot was started/restarted/created after the message was created. The message ID is: {}", msgId);
@@ -57,21 +58,14 @@ public class HighlightedMessage extends ListenerAdapter {
                     .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with (discord message) id: " + msgId))
                     .discordId();
 
-            //this currently returns null if used on bots since we dont store their ID in DB,
-            // this is currently our expected behavior if we want to support bots
-            // we'd just have to store their messages in DB
-            // currently cus msg doesnt exist we return a default Message object with defaults: userid as 0 which
-            // obv doesnt exist so results in null below
-            var user = event.getJDA().getUserById(msgAuthorId);
+            User user = event.getJDA().getUserById(msgAuthorId);
             if (Objects.isNull(user)) {
-                log.error("[onMessageReactionAdd] user object is NULL, they are not stored in the database. Cannot highlight any of their messages.");
+                log.error("[onMessageReactionAdd] Cannot retrieve user from database, they are not stored in the database. Cannot highlight any of their messages.");
                 return;
             }
 
-            starMsgDao.create(new StarMessage(msgId, 0, false, 0));//init the bs thing
-
-            // we query this one later as perf improvement in case the user is null above
-            var starMsgObject = starMsgDao.get(msgId);
+            starMessageDao.create(new StarMessage(msgId, 0, false, 0));
+            Optional<StarMessage> starMsgObject = starMessageDao.get(msgId);
 
             int starAmount = starMsgObject
                     .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
@@ -94,12 +88,9 @@ public class HighlightedMessage extends ListenerAdapter {
                     .attachmentsLinks();
 
             int newStarAmount = starAmount + 1;
+            starMessageDao.update(new StarMessage(msgId, newStarAmount, isSent, embedMsgId));
 
-            // update w new star amount
-            starMsgDao.update(new StarMessage(msgId, newStarAmount, isSent, embedMsgId));
-
-            //extract media URL from message
-            Pattern pattern = Pattern.compile("https?\\S+" +
+            Pattern findMediaUrls = Pattern.compile("https?\\S+" +
                     "(?:\\.avi|" +
                     "\\.gif|" +
                     "\\.heic|" +
@@ -110,7 +101,7 @@ public class HighlightedMessage extends ListenerAdapter {
                     "\\.png|" +
                     "\\.webm|" +
                     "\\.webp)\\S*", Pattern.CASE_INSENSITIVE);
-            Matcher matcher = pattern.matcher(msgContent);
+            Matcher matcher = findMediaUrls.matcher(msgContent);
             String mediaUrl;
 
             boolean hasMediaLink;
@@ -125,39 +116,32 @@ public class HighlightedMessage extends ListenerAdapter {
             boolean hasAttachments;
             if (attachmentLinks.isEmpty())
                 hasAttachments = false;
-            else {
+            else
                 hasAttachments = true;
-            }
 
             if (newStarAmount >= BotConfig.getHighlightStarThresholdInt()){
 
-                String stars = Integer.valueOf(newStarAmount).toString();
-                EmbedBuilder embedHighlight = getBaseEmbedMessage(user, stars, msgContent);
-                TextChannel darwinChannel = event.getGuild()
-                        .getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID);
+                String newStarAmountAsString = Integer.valueOf(newStarAmount).toString();
+                EmbedBuilder embedHighlight = getBaseEmbedMessage(user, newStarAmountAsString, msgContent);
+                TextChannel darwinChannel = event.getGuild().getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID);
 
-                //prevent sending duplicates
                 if (!isSent) {
-
-                    isSent = true;
 
                     if (msgContent.length() <= 1024) {
 
-                        boolean finalIsSent = isSent;
                         darwinChannel
                                 .sendMessageEmbeds(embedHighlight.build())
                                 .queue(message -> {
                                     long newEmbedMsgId = message.getIdLong();
-                                    starMsgDao.update(new StarMessage(msgId, newStarAmount, finalIsSent, newEmbedMsgId));
+                                    starMessageDao.update(new StarMessage(msgId, newStarAmount, true, newEmbedMsgId));
 
                                     if (hasAttachments || hasMediaLink)
                                         darwinChannel.sendMessage("Attachments: " + attachmentLinks + " " + mediaUrl).queue();
-
                                 });
                     } else {
 
                         try {
-                            var myFile = new File("long_message.txt");
+                            File myFile = new File("long_message.txt");
                             if (myFile.createNewFile()) {
 
                                 FileWriter fw = new FileWriter(myFile);
@@ -165,33 +149,24 @@ public class HighlightedMessage extends ListenerAdapter {
                                 fw.flush();
                                 fw.close();
 
-                                boolean finalIsSent = isSent;
-                                //so for some reason using FileUpload with sendFiles
-                                // makes the text file above the embed which is ugly as fk,
-                                //so we do it manual way but this makes it so that
-                                // if we ever want to be able to delete msghihglight + attachments
-                                // we'll have to store EACH attachement msg id
-                                // i think we r fine tho since wont need this
                                 darwinChannel
                                         .sendMessageEmbeds(embedHighlight.build())
                                         .queue(message -> {
-                                            var newEmbedMsgId = message.getIdLong();
-                                            starMsgDao.update(new StarMessage(msgId, newStarAmount, finalIsSent, newEmbedMsgId));
+                                            long newEmbedMsgId = message.getIdLong();
+                                            starMessageDao.update(new StarMessage(msgId, newStarAmount, true, newEmbedMsgId));
 
                                             if (hasAttachments || hasMediaLink)
                                                 darwinChannel.sendMessage("Attachments: " + attachmentLinks + " " + mediaUrl).queue();
                                         });
 
                                 darwinChannel.sendFiles(FileUpload.fromData(myFile)).queue();
-                                myFile.delete();//ignore the warning, we want to delete this
+                                myFile.delete();
                             }
                         } catch (IOException e) {
                             log.error("[onMessageReactionAdd] Something went wrong while trying to create and upload text file to discord.");
                             log.error(e.getMessage());
                         }
                     }
-
-                    //if message was already sent (we edit to update stars amount instead of sending a new embed):
                 } else {
 
                     darwinChannel
@@ -210,13 +185,13 @@ public class HighlightedMessage extends ListenerAdapter {
                 .asUnicode()
                 .getAsCodepoints();
 
-        if (emojiAsUnicode.equalsIgnoreCase(starEmojiUnicode)) {
+        if (emojiAsUnicode.equalsIgnoreCase(STAR_EMOJI_UNICODE)) {
 
             long msgId = event.getMessageIdLong();
-            var starMsgDao = new StarMessageDao();
-            var msgDao = new MessageDao();
+            StarMessageDao starMessageDao = new StarMessageDao();
+            MessageDao messageDao = new MessageDao();
 
-            var msgObject = msgDao.get(msgId);
+            Optional<DiscordMessage> msgObject = messageDao.get(msgId);
 
             long msgAuthorId = msgObject
                     .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with (discord message) id: " + msgId))
@@ -228,7 +203,7 @@ public class HighlightedMessage extends ListenerAdapter {
                 return;
             }
 
-            var starMsgObject = starMsgDao.get(msgId);
+            Optional<StarMessage> starMsgObject = starMessageDao.get(msgId);
 
             int starAmount = starMsgObject
                     .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
@@ -248,17 +223,15 @@ public class HighlightedMessage extends ListenerAdapter {
 
             int newStarAmount = starAmount - 1;
 
-            String stars = Integer.valueOf(newStarAmount).toString();
-
-            EmbedBuilder embedHighlight = getBaseEmbedMessage(user, stars, msgContent);
-
+            String newStarAmountAsString = Integer.valueOf(newStarAmount).toString();
+            EmbedBuilder embedHighlight = getBaseEmbedMessage(user, newStarAmountAsString, msgContent);
             TextChannel darwinChannel = event.getGuild().getChannelById(TextChannel.class, BotConfig.DARWIN_CHANNEL_ID);
 
             darwinChannel
                     .editMessageEmbedsById(embedMsgId, embedHighlight.build())
                     .queue();
 
-            starMsgDao.update(new StarMessage(msgId, newStarAmount, isSent, embedMsgId));
+            starMessageDao.update(new StarMessage(msgId, newStarAmount, isSent, embedMsgId));
         }
     }
 

--- a/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
+++ b/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
@@ -54,7 +54,7 @@ public class HighlightedMessage extends ListenerAdapter {
             }
             
             long msgAuthorId = msgObject
-                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with id: ", msgId))
+                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with (discord message) id: " + msgId))
                     .discordId();
 
             //this currently returns null if used on bots since we dont store their ID in DB,
@@ -74,23 +74,23 @@ public class HighlightedMessage extends ListenerAdapter {
             var starMsgObject = starMsgDao.get(msgId);
 
             int starAmount = starMsgObject
-                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with id: ", msgId))
+                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
                     .starAmount();
 
             boolean isSent = starMsgObject
-                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with id: ", msgId))
+                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
                     .isSent();
 
             long embedMsgId = starMsgObject
-                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with id: ", msgId))
+                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
                     .embedMessageId();
 
             String msgContent = msgObject
-                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with id: ", msgId))
+                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with (discord message) id: " + msgId))
                     .messageContent();
 
             String attachmentLinks = msgObject
-                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with id: ", msgId))
+                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with (discord message) id: " + msgId))
                     .attachmentsLinks();
 
             int newStarAmount = starAmount + 1;
@@ -219,7 +219,7 @@ public class HighlightedMessage extends ListenerAdapter {
             var msgObject = msgDao.get(msgId);
 
             long msgAuthorId = msgObject
-                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with id: ", msgId))
+                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with (discord message) id: " + msgId))
                     .discordId();
 
             User user = event.getJDA().getUserById(msgAuthorId);
@@ -231,19 +231,19 @@ public class HighlightedMessage extends ListenerAdapter {
             var starMsgObject = starMsgDao.get(msgId);
 
             int starAmount = starMsgObject
-                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with id: ", msgId))
+                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
                     .starAmount();
 
             boolean isSent = starMsgObject
-                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with id: ", msgId))
+                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
                     .isSent();
 
             long embedMsgId = starMsgObject
-                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with id: ", msgId))
+                    .orElseThrow(() -> new StarMessageNotFoundException("Failure trying to retrieve star message from database with (discord message) id: " + msgId))
                     .embedMessageId();
 
             String msgContent = msgObject
-                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with id: ", msgId))
+                    .orElseThrow(() -> new MessageNotFoundException("Failure while trying to retrieve message from database with (discord message) id: " + msgId))
                     .messageContent();
 
             int newStarAmount = starAmount - 1;


### PR DESCRIPTION
- **refactor: simplified admin slash cmds**
- **refactor: simplified ping cmd**
- **chore: cleanup**
- **docs: simplified**
- **fix: prevent content or attachement links from being cutt of if too long**
- **git: ignore emacs auto-save files and bin folder**
- **chore: remove var**
- **fix: remove useless call to getInteraction**
- **chore: remove var**
- **refactor: keep exceptions simple**
- **refactor: simplify error log method**
- **perf: removed redundant loops for static approach**
- **refactor: place combined word check outside loop**
- **refactor: removed exessive stuff**
- **perf: use stringbuilder**
- **docs: added contributing guidelines**
- **perf: use stringbuilder**
- **refactor: remove var**
- **refactor: remove var and fix name conflict**
- **refactor: remove var**
- **style: removed comments and breaklines where possible**
- **docs: rewrite**
- **perf: use stringbuilder**
- **docs: generalize**
- **style: stylistic changes**

Closes #64, #108

**By opening this pull request I confirm:**
- [x] I tested the code
- [x] I kept things as simple as possible
- [x] I added in-line documentation (if needed)

**Description**

Concretely, removed var in favor of static datatypes, fixed some bugs and most importantly rewrote most of banned words filter to make it more simple.

PR needed to ensure rembot isn't overcomplicated and as a last check that everything is ok.

Reread all of rembot to prepare for v1.0.0 release. 

**Screenshots (optional)**

n/a
