### PR TITLE
feat/delete message logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Features
         Auto-delete messages that contain a banned word(s)
         Auto-mute users who spam (mute detection can be customized)
         Auto-delete messages that include a discord server/guild invite link
+        Deleted messages are logged in a log channel
     Other
         Message highlight based on the star emoji
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Features
         Auto-delete messages that include a discord server/guild invite link
         Deleted messages are logged in a log channel
     Other
-        Message highlight based on the star emoji
+        Message highlight based on the star emoji reaction
 ```
 
 ## Quickstart:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Slash Commands (/)
         /unmute username [reason]
 Non-Slash Commands (&)
     &ping - returns "pong", time took in milliseconds (ms) and what version of rembot is running.
+Features
+    Moderation
+        Auto-delete messages that contain a banned word(s)
+        Auto-mute users who spam (mute detection can be customized)
+        Auto-delete messages that include a discord server/guild invite link
+    Other
+        Message highlight based on the star emoji
 ```
 
 ## Quickstart:

--- a/src/main/java/va/rembot/BotConfig.java
+++ b/src/main/java/va/rembot/BotConfig.java
@@ -14,6 +14,7 @@ import va.rembot.commands.non_slash.PingPong;
 import va.rembot.commands.slash.admin.*;
 import va.rembot.moderation.AntiSpamFilter;
 import va.rembot.moderation.AutoDeleteDiscordInviteLinks;
+import va.rembot.moderation.DeletedMessage;
 import va.rembot.moderation.word_filter.BannedWordsFilter;
 import va.rembot.other.highlight.HighlightedMessage;
 
@@ -224,16 +225,18 @@ public class BotConfig extends ListenerAdapter {
             log.warn("[onReady] REPLICATE_AMOUNT is set to 0 or a negative number, this means that banned words are not replicated this is probably not what you want. Check your .env file.");
 
         bot.addEventListener(
+                new BannedWordsFilter(),
+                new AntiSpamFilter(),
+                new AutoDeleteDiscordInviteLinks(),
+                new HighlightedMessage(),
+                new DeletedMessage(),
+                // slash commands
                 new Ban(),
                 new Unban(),
                 new Kick(),
                 new Mute(),
                 new Unmute(),
-                new BannedWordsFilter(),
-                new AntiSpamFilter(),
-                new AutoDeleteDiscordInviteLinks(),
-                new HighlightedMessage(),
-                // non slash
+                // non-slash commands
                 new PingPong());
 
         bot.updateCommands()

--- a/src/main/java/va/rembot/lib/ExtractFromMessage.java
+++ b/src/main/java/va/rembot/lib/ExtractFromMessage.java
@@ -1,0 +1,29 @@
+package va.rembot.lib;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ExtractFromMessage {
+
+    public static String extractMediaUrls(String message) {
+
+        Pattern findMediaUrls = Pattern.compile("https?\\S+" +
+                "(?:\\.avi|" +
+                "\\.gif|" +
+                "\\.heic|" +
+                "\\.jpe?g|" +
+                "\\.mkv|" +
+                "\\.mov|" +
+                "\\.mp4|" +
+                "\\.png|" +
+                "\\.webm|" +
+                "\\.webp)\\S*", Pattern.CASE_INSENSITIVE);
+
+        Matcher matcher = findMediaUrls.matcher(message);
+
+        if (matcher.find())
+            return matcher.group();
+        else
+            return "";
+    }
+}

--- a/src/main/java/va/rembot/lib/ExtractFromMessage.java
+++ b/src/main/java/va/rembot/lib/ExtractFromMessage.java
@@ -12,10 +12,12 @@ public class ExtractFromMessage {
                 "\\.gif|" +
                 "\\.heic|" +
                 "\\.jpe?g|" +
+                "\\.m4v|" +
                 "\\.mkv|" +
                 "\\.mov|" +
                 "\\.mp4|" +
                 "\\.png|" +
+                "\\.svg|" +
                 "\\.webm|" +
                 "\\.webp)\\S*", Pattern.CASE_INSENSITIVE);
 

--- a/src/main/java/va/rembot/lib/ExtractFromMessage.java
+++ b/src/main/java/va/rembot/lib/ExtractFromMessage.java
@@ -26,4 +26,19 @@ public class ExtractFromMessage {
         else
             return "";
     }
+
+    public static boolean endsWithUrl(String message) {
+        Pattern pattern = Pattern.compile("https?://\\S+$");
+        Matcher matcher = pattern.matcher(message);
+
+        return matcher.find();
+    }
+
+    public static boolean hasDiscordInviteLink(String message) {
+
+        Pattern pattern = Pattern.compile("\\S*discord(?:\\.gg|\\.com\\/invite)\\S+");
+        Matcher matcher = pattern.matcher(message);
+
+        return matcher.find();
+    }
 }

--- a/src/main/java/va/rembot/moderation/AntiSpamFilter.java
+++ b/src/main/java/va/rembot/moderation/AntiSpamFilter.java
@@ -47,7 +47,7 @@ public class AntiSpamFilter extends ListenerAdapter {
         StringBuilder attachmentLinks = new StringBuilder();
 
         for (Attachment file : msg.getAttachments())
-             attachmentLinks.append(file.getUrl()).append(" ");
+            attachmentLinks.append(file.getUrl()).append(" ");
 
         userDao.create(new DiscordUser(discordId));
         messageDao.create(new DiscordMessage(discordMsgId, discordId, new Timestamp(msgCreated), msgContent, attachmentLinks.toString()));

--- a/src/main/java/va/rembot/moderation/AutoDeleteDiscordInviteLinks.java
+++ b/src/main/java/va/rembot/moderation/AutoDeleteDiscordInviteLinks.java
@@ -3,9 +3,7 @@ package va.rembot.moderation;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import va.rembot.lib.ExtractFromMessage;
 
 public class AutoDeleteDiscordInviteLinks extends ListenerAdapter {
 
@@ -16,14 +14,13 @@ public class AutoDeleteDiscordInviteLinks extends ListenerAdapter {
         Message message = event.getMessage();
         String messageContent = message.getContentRaw();
 
-        Pattern pattern = Pattern.compile("\\S*discord(?:\\.gg|\\.com\\/invite)\\S+");
-        Matcher matcher = pattern.matcher(messageContent);
+        boolean messageIncludesDiscordInviteLink = ExtractFromMessage.hasDiscordInviteLink(messageContent);
 
-        if (matcher.find()) {
-           event.getChannel()
-                   .sendMessage("Discord invite links are not allowed.")
-                   .and(message.delete())
-                   .queue();
+        if (messageIncludesDiscordInviteLink) {
+            event.getChannel()
+                    .sendMessage("Discord invite links are not allowed.")
+                    .and(message.delete())
+                    .queue();
         }
     }
 }

--- a/src/main/java/va/rembot/moderation/DeletedMessage.java
+++ b/src/main/java/va/rembot/moderation/DeletedMessage.java
@@ -1,0 +1,83 @@
+package va.rembot.moderation;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.utils.FileUpload;
+import va.rembot.BotConfig;
+import va.rembot.database.dao.MessageDao;
+import va.rembot.database.models.DiscordMessage;
+import va.rembot.exceptions.MessageNotFoundException;
+import va.rembot.lib.ExtractFromMessage;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
+public class DeletedMessage extends ListenerAdapter {
+
+    @Override
+    public void onMessageDelete(MessageDeleteEvent event) {
+        long messageId = event.getMessageIdLong();
+        long discordUserId;
+        String messageContent;
+        String attachmentLinks;
+        String author;
+        TextChannel logChannel = event.getGuild().getChannelById(TextChannel.class, BotConfig.LOG_CHANNEL_ID);
+
+        MessageDao messageDao = new MessageDao();
+        Optional<DiscordMessage> messageObject = messageDao.get(messageId);
+
+        discordUserId = messageObject.orElseThrow(() -> new MessageNotFoundException("Could not retrieve message from database.")).discordId();
+        messageContent = messageObject.orElseThrow(() -> new MessageNotFoundException("Could not retrieve message from database.")).messageContent();
+        attachmentLinks = messageObject.orElseThrow(() -> new MessageNotFoundException("Could not retrieve message from database.")).attachmentsLinks();
+
+        Member user = event.getGuild().getMemberById(discordUserId);
+
+        if (Objects.isNull(user)) {
+            author = "Unknown author";
+            messageContent = "Message content unknown. (Was not saved in database).";
+        } else
+            author = user.getAsMention();
+
+        String mediaUrl = ExtractFromMessage.extractMediaUrls(messageContent);
+
+        if (!mediaUrl.isEmpty())
+            messageContent = messageContent.replace(mediaUrl, "");
+
+        if (messageContent.length() + attachmentLinks.length() <= 1900) {
+            String finalMessageContent = messageContent;
+            logChannel.sendMessage("**[MESSAGE DELETED]** " + author + " <C:" + messageContent + ">\n" + attachmentLinks + mediaUrl)
+                    .queue(success -> {
+                        log.info("[onMessageDelete] Message was deleted by: {} message content: {} attachment links: {}", author, finalMessageContent, attachmentLinks);
+                    });
+        } else {
+            try {
+                File file = new File("long_message_deleted.txt");
+
+                if (file.createNewFile()) {
+                    FileWriter fw = new FileWriter(file);
+                    fw.write(messageContent);
+                    fw.flush();
+                    fw.close();
+
+                    logChannel
+                            .sendMessage("**[MESSAGE DELETED]** " + author + " <C:" + "Message content was too long see attached file below for original message.>\n" + attachmentLinks + mediaUrl)
+                            .and(logChannel.sendFiles(FileUpload.fromData(file)))
+                            .queue();
+                    file.delete();
+                }
+
+            } catch (IOException e) {
+                log.error("[onMessageDelete] Something went wrong while storing deleted message as file format.");
+                log.error("[onMessageDelete] Error: {}", e.getMessage());
+                log.error("[onMessageDelete] Stack trace: {}", e.getStackTrace());
+            }
+        }
+    }
+}

--- a/src/main/java/va/rembot/moderation/DeletedMessage.java
+++ b/src/main/java/va/rembot/moderation/DeletedMessage.java
@@ -82,7 +82,7 @@ public class DeletedMessage extends ListenerAdapter {
             } catch (IOException e) {
                 log.error("[onMessageDelete] Something went wrong while storing deleted message as file format.");
                 log.error("[onMessageDelete] Error: {}", e.getMessage());
-                log.error("[onMessageDelete] Stack trace: {}", e.getStackTrace());
+                log.error("[onMessageDelete] Stack trace: {}", (Object) e.getStackTrace());
             }
         }
     }

--- a/src/main/java/va/rembot/moderation/DeletedMessage.java
+++ b/src/main/java/va/rembot/moderation/DeletedMessage.java
@@ -50,11 +50,14 @@ public class DeletedMessage extends ListenerAdapter {
         if (!mediaUrl.isEmpty())
             messageContent = messageContent.replace(mediaUrl, "");
 
+        if (ExtractFromMessage.endsWithUrl(messageContent))
+            messageContent = messageContent + " ";
+
         if (messageContent.length() + attachmentLinks.length() <= 1900) {
             String finalMessageContent = messageContent;
             logChannel.sendMessage("**[MESSAGE DELETED]** " + author + " <C:" + messageContent + ">\n" + attachmentLinks + mediaUrl)
                     .queue(success -> {
-                        log.info("[onMessageDelete] Message was deleted by: {} message content: {} attachment links: {}", author, finalMessageContent, attachmentLinks);
+                        log.info("[onMessageDelete] Message was deleted by: {} message content: {} attachment links: {}", user, finalMessageContent, attachmentLinks);
                     });
         } else {
             try {
@@ -66,10 +69,13 @@ public class DeletedMessage extends ListenerAdapter {
                     fw.flush();
                     fw.close();
 
+                    String finalMessageContent = messageContent;
                     logChannel
                             .sendMessage("**[MESSAGE DELETED]** " + author + " <C:" + "Message content was too long see attached file below for original message.>\n" + attachmentLinks + mediaUrl)
                             .and(logChannel.sendFiles(FileUpload.fromData(file)))
-                            .queue();
+                            .queue(success -> {
+                                log.info("[onMessageDelete] Message was deleted by: {} message content: {} attachment links: {}", user, finalMessageContent, attachmentLinks);
+                            });
                     file.delete();
                 }
 

--- a/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
+++ b/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
@@ -18,6 +18,7 @@ import va.rembot.database.models.StarMessage;
 import va.rembot.database.models.DiscordUser;
 import va.rembot.exceptions.MessageNotFoundException;
 import va.rembot.exceptions.StarMessageNotFoundException;
+import va.rembot.lib.ExtractFromMessage;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -25,8 +26,6 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Slf4j
 public class HighlightedMessage extends ListenerAdapter {
@@ -90,28 +89,13 @@ public class HighlightedMessage extends ListenerAdapter {
             int newStarAmount = starAmount + 1;
             starMessageDao.update(new StarMessage(msgId, newStarAmount, isSent, embedMsgId));
 
-            Pattern findMediaUrls = Pattern.compile("https?\\S+" +
-                    "(?:\\.avi|" +
-                    "\\.gif|" +
-                    "\\.heic|" +
-                    "\\.jpe?g|" +
-                    "\\.mkv|" +
-                    "\\.mov|" +
-                    "\\.mp4|" +
-                    "\\.png|" +
-                    "\\.webm|" +
-                    "\\.webp)\\S*", Pattern.CASE_INSENSITIVE);
-            Matcher matcher = findMediaUrls.matcher(msgContent);
-            String mediaUrl;
-
+            String mediaUrl = ExtractFromMessage.extractMediaUrls(msgContent);
             boolean hasMediaLink;
-            if (matcher.find()) {
-                hasMediaLink = true;
-                mediaUrl = matcher.group();
-            } else {
+
+            if (mediaUrl.isEmpty())
                 hasMediaLink = false;
-                mediaUrl = "";
-            }
+            else
+                hasMediaLink = true;
 
             boolean hasAttachments;
             if (attachmentLinks.isEmpty())

--- a/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
+++ b/src/main/java/va/rembot/other/highlight/HighlightedMessage.java
@@ -2,6 +2,8 @@ package va.rembot.other.highlight;
 
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.Message.Attachment;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -223,23 +225,22 @@ public class HighlightedMessage extends ListenerAdapter {
     public void onMessageReceived(MessageReceivedEvent event) {
         if (event.getAuthor().isBot()) return;
 
-        var msgDao = new MessageDao();
-        var userDao = new UserDao();
+        MessageDao msgDao = new MessageDao();
+        UserDao userDao = new UserDao();
 
-        var msg = event.getMessage();
+        Message msg = event.getMessage();
         String msgContent = msg.getContentRaw();
         long discordMsgId = event.getMessageIdLong();
         long discordId = event.getAuthor().getIdLong();
         long msgTimeCreated = msg.getTimeCreated().toInstant().toEpochMilli();
 
-        String attachmentLinks = "";
+        StringBuilder attachmentLinks = new StringBuilder();
 
-        for (var file : msg.getAttachments()) {
-            attachmentLinks += file.getUrl() + " ";
-        }
+        for (Attachment attachment : msg.getAttachments())
+            attachmentLinks.append(attachment.getUrl()).append(" ");
 
         userDao.create(new DiscordUser(discordId));
-        msgDao.create(new DiscordMessage(discordMsgId, discordId, new Timestamp(msgTimeCreated), msgContent, attachmentLinks));
+        msgDao.create(new DiscordMessage(discordMsgId, discordId, new Timestamp(msgTimeCreated), msgContent, attachmentLinks.toString()));
     }
 
     private static EmbedBuilder getBaseEmbedMessage(User user, String stars, String messageContent) {


### PR DESCRIPTION
- **feat: created delete message logger**
- **docs: updated readme to information of features**
- **fix: fixed links bein invalid if they were at the end of the deleted message**

Closes #125

**By opening this pull request I confirm:**
- [x] I tested the code
- [x] I kept things as simple as possible
- [x] I added documentation (if relevant)

**Description**

Created a logger for deleted messages. Mods need to be able to view deleted messages. Aditionally, we can't retrieve messages we haven't stored in database so for example messages that are auto-deleted after a while (cleaning up database) can't be logged and would be replaced with a placeholder "unknown author" "Message content unknown"

**Screenshots (optional)**

